### PR TITLE
Tables and tool to import map data sources

### DIFF
--- a/app/backend/deps.edn
+++ b/app/backend/deps.edn
@@ -36,7 +36,7 @@
              "datomic-cloud" {:url "s3://datomic-releases-1fc2183a/maven/releases"}
 
              }
- :paths ["src/clj" "../common/src/cljc" "resources"]
+ :paths ["src/clj" "../common/src/cljc" "../common/src/clj" "resources"]
  :aliases {:dev {:extra-deps {com.datomic/ion-dev {:mvn/version "0.9.234"}}}
            :pack {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
                                                 :sha "2769a6224bfb938e777906ea311b3daf7d2220f5"}}}

--- a/app/backend/src/clj/teet/db_api/db_api_handlers.clj
+++ b/app/backend/src/clj/teet/db_api/db_api_handlers.clj
@@ -19,7 +19,7 @@
             teet.project.project-commands
 
             [teet.log :as log]
-            [teet.login.login-api-token :as login-api-token]
+            [teet.auth.jwt-token :as jwt-token]
             [clojure.string :as str]))
 
 (defn- jwt-token [req]
@@ -33,7 +33,7 @@
   (fn [req]
     (log/debug "REQUEST: " (pr-str req))
     (try
-      (let [user (some->> req jwt-token (login-api-token/verify-token
+      (let [user (some->> req jwt-token (jwt-token/verify-token
                                          (environment/config-value :auth :jwt-secret)))]
         (log/with-context
           {:user (str (:user/id user))}

--- a/app/backend/src/clj/teet/login/login_commands.clj
+++ b/app/backend/src/clj/teet/login/login_commands.clj
@@ -1,7 +1,7 @@
 (ns teet.login.login-commands
   (:require [teet.db-api.core :as db-api]
             [teet.environment :as environment]
-            [teet.login.login-api-token :as login-api-token]
+            [teet.auth.jwt-token :as jwt-token]
             [datomic.client.api :as d]
             [teet.log :as log]))
 
@@ -51,13 +51,13 @@
   (if (environment/check-site-password site-password)
     (let [secret (environment/config-value :auth :jwt-secret)
           roles (user-roles conn id)]
-      {:token (login-api-token/create-token secret "teet_user"
-                                            {:given-name given-name
-                                             :family-name family-name
-                                             :person-id person-id
-                                             :email email
-                                             :id id
-                                             :roles roles})
+      {:token (jwt-token/create-token secret "teet_user"
+                                      {:given-name given-name
+                                       :family-name family-name
+                                       :person-id person-id
+                                       :email email
+                                       :id id
+                                       :roles roles})
        :user (user-info conn id)
        :roles roles
        :enabled-features (environment/config-value :enabled-features)
@@ -86,7 +86,7 @@
                                  (if (empty? roles)
                                    "?error=no-roles"
                                    (str "?token="
-                                        (login-api-token/create-token
+                                        (jwt-token/create-token
                                          secret "teet_user"
                                          {:given-name given_name
                                           :family-name family_name
@@ -106,13 +106,13 @@
 (defmethod db-api/command! :refresh-token [{conn :conn
                                             {:user/keys [id given-name family-name email person-id]} :user} _]
   (let [roles (user-roles conn id)]
-    {:token (login-api-token/create-token (environment/config-value :auth :jwt-secret) "teet_user"
-                                          {:given-name given-name
-                                           :family-name family-name
-                                           :person-id person-id
-                                           :email email
-                                           :id id
-                                           :roles roles})
+    {:token (jwt-token/create-token (environment/config-value :auth :jwt-secret) "teet_user"
+                                    {:given-name given-name
+                                     :family-name family-name
+                                     :person-id person-id
+                                     :email email
+                                     :id id
+                                     :roles roles})
      :user (user-info conn id)
      :roles roles
      :enabled-features (environment/config-value :enabled-features)

--- a/app/backend/src/clj/teet/project/project_geometry.clj
+++ b/app/backend/src/clj/teet/project/project_geometry.clj
@@ -2,7 +2,7 @@
   "Code for working with project geometries stored in PostgreSQL.
   Provides functions for calling the PostgREST API."
   (:require [org.httpkit.client :as client]
-            [teet.login.login-api-token :as login-api-token]
+            [teet.auth.jwt-token :as jwt-token]
             [clojure.string :as str]
             [cheshire.core :as cheshire]))
 
@@ -37,7 +37,7 @@
                        {:headers {"Content-Type" "application/json"
                                   "Authorization"
                                   (str "Bearer "
-                                       (login-api-token/create-backend-token api-shared-secret))}
+                                       (jwt-token/create-backend-token api-shared-secret))}
                         :body (cheshire/encode request-body)})]
         (when-not (= 200 (:status response))
           (throw (ex-info "Update project geometries failed"

--- a/app/backend/src/clj/teet/routes.clj
+++ b/app/backend/src/clj/teet/routes.clj
@@ -3,7 +3,7 @@
             [compojure.route :refer [resources files]]
             [teet.index.index-page :as index-page]
             [cheshire.core :as cheshire]
-            [teet.login.login-api-token :as login-api-token]))
+            [teet.auth.jwt-token :as jwt-token]))
 
 (defn teet-routes [config]
   (routes
@@ -17,7 +17,7 @@
                  (if-let [user (get-in req [:session :user])]
                    (merge user
                           {:authenticated? true
-                           :api-token (login-api-token/create-token
+                           :api-token (jwt-token/create-token
                                        (get-in config [:api :shared-secret])
                                        (get-in config [:api :role])
                                        user)})

--- a/app/backend/src/clj/teet/thk/thk_integration_ion.clj
+++ b/app/backend/src/clj/teet/thk/thk_integration_ion.clj
@@ -10,7 +10,6 @@
             [teet.thk.thk-export :as thk-export]
             [teet.environment :as environment]
             [datomic.client.api :as d]
-            [teet.login.login-api-token :as login-api-token]
             [clojure.data.csv :as csv]
             [teet.project.project-geometry :as project-geometry]))
 

--- a/app/common/src/clj/teet/auth/jwt_token.clj
+++ b/app/common/src/clj/teet/auth/jwt_token.clj
@@ -1,5 +1,5 @@
-(ns teet.login.login-api-token
-  "Create JWT token for PostgREST API"
+(ns teet.auth.jwt-token
+  "Create JWT token for TEET backend and PostgREST API"
   (:import (java.security SecureRandom)
            (com.nimbusds.jose JWSAlgorithm JWSSigner JWSObject JWSHeader JWSVerifier Payload)
            (com.nimbusds.jose.crypto MACSigner MACVerifier)

--- a/app/common/src/cljc/teet/util/string.cljc
+++ b/app/common/src/cljc/teet/util/string.cljc
@@ -1,0 +1,14 @@
+(ns teet.util.string
+  "String utilities"
+  (:require [clojure.string :as str]))
+
+(defn interpolate
+  "Replace parameter references in curly braces in the input string with values from parameters.
+  Example: \"Hello, {name}!\" would replace \"{name}\" with the :name parameter."
+  [string parameters]
+  (str/replace string
+               #"\{([^\}]+)\}"
+               (fn [[_ param-name]]
+                 (str
+                  (get parameters (keyword param-name)
+                       (str "[MISSING PARAMETER " param-name "]"))))))

--- a/app/datasource-import/deps.edn
+++ b/app/datasource-import/deps.edn
@@ -1,4 +1,5 @@
-{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+{:paths ["src" "../common/src/cljc"]
+ :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.geotools/gt-shapefile {:mvn/version "22.2"
                                    ;; We won't need image manipulation library
                                    :exclusions [javax.media/jai_core]}

--- a/app/datasource-import/deps.edn
+++ b/app/datasource-import/deps.edn
@@ -1,0 +1,12 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.1"}
+        org.geotools/gt-shapefile {:mvn/version "22.2"
+                                   ;; We won't need image manipulation library
+                                   :exclusions [javax.media/jai_core]}
+
+        clj-http {:mvn/version "3.10.0"}
+        cheshire {:mvn/version "5.9.0"}
+        }
+ :mvn/repos {;; geotools in boundless
+             "boundless" {:url "https://repo.boundlessgeo.com/main/"}
+             ;; jgridshift library in osgeo
+             "osgeo" {:url "https://download.osgeo.org/webdav/geotools/"}}}

--- a/app/datasource-import/deps.edn
+++ b/app/datasource-import/deps.edn
@@ -1,4 +1,4 @@
-{:paths ["src" "../common/src/cljc"]
+{:paths ["src" "../common/src/cljc" "../common/src/clj"]
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         org.geotools/gt-shapefile {:mvn/version "22.2"
                                    ;; We won't need image manipulation library
@@ -6,6 +6,10 @@
 
         clj-http {:mvn/version "3.10.0"}
         cheshire {:mvn/version "5.9.0"}
+
+        com.nimbusds/nimbus-jose-jwt {:mvn/version "7.8"
+                                      :exclusions [net.minidev/json-smart]}
+        net.minidev/json-smart {:mvn/version "2.3"}
         }
  :mvn/repos {;; geotools in boundless
              "boundless" {:url "https://repo.boundlessgeo.com/main/"}

--- a/app/datasource-import/example-config.edn
+++ b/app/datasource-import/example-config.edn
@@ -1,0 +1,3 @@
+{:api-url "http://localhost:3000"
+ :api-secret "secret1234567890secret1234567890"
+ :datasource-id 1}

--- a/app/datasource-import/src/teet/datasource_import/core.clj
+++ b/app/datasource-import/src/teet/datasource_import/core.clj
@@ -1,0 +1,80 @@
+(ns teet.datasource-import.core
+  "Main for TEET datasource import."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clj-http.client :as client]
+            [cheshire.core :as cheshire]
+            [teet.datasource-import.shp :as shp])
+  (:import (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)
+           (java.util.zip ZipEntry ZipInputStream)))
+
+(defn valid-api? [{:keys [api-url api-secret]}]
+  (and (not (str/blank? api-url))
+       (not (str/blank? api-secret))))
+
+(defn valid-datasource? [{:keys [datasource-id]}]
+  (integer? datasource-id))
+
+(defn fetch-datasource-config [{:keys [api-url api-secret datasource-id] :as ctx}]
+  (let [response (client/get (str api-url "/datasource?id=eq." datasource-id) {:as :json})]
+    (assoc ctx :datasource (-> response :body first))))
+
+(defn download-datasource [{{:keys [url]} :datasource :as ctx}]
+  (let [download-path (Files/createTempDirectory
+                       "datasource-download"
+                       (into-array FileAttribute []))
+        download-file (io/file (.toFile download-path)
+                               "datasource")]
+    (println "Downloading" url "to" (.getAbsolutePath download-file))
+    (with-open [out (io/output-stream download-file)]
+      (let [{in :body
+             headers :headers} (client/get url {:as :stream})]
+        (io/copy in out)
+        (assoc ctx
+               :downloaded-datasource {:path download-path
+                                       :file download-file
+                                       :content-type (get headers :content-type)})))))
+
+
+(defn extract-datasource [{dds :downloaded-datasource :as ctx}]
+  (when (= "application/zip" (:content-type dds))
+    (with-open [in (ZipInputStream. (io/input-stream (:file dds)))]
+      (loop []
+        (when-let [entry (.getNextEntry in)]
+          (let [file (io/file (.toFile (:path dds))
+                              (.getName entry))]
+            (println "Extract" (.getName entry) "to"
+                     (.getAbsolutePath file))
+            (with-open [out (io/output-stream file)]
+              (io/copy in out)))
+          (recur)))))
+  ctx)
+
+(defn read-features [{dds :downloaded-datasource
+                      ds :datasource
+                      :as ctx}]
+  (assoc
+   ctx :features
+   (case (:content_type ds)
+     "SHP" (shp/read-features-from-path (:path dds)))))
+
+(defn dump-ctx [ctx]
+  (spit "debug-ctx" (pr-str ctx)))
+
+(defn -main [& args]
+  (let [[config-file] args]
+    (assert (and config-file
+                 (.canRead (io/file config-file)))
+            "Specify config file to read")
+    (let [config (-> config-file slurp read-string)]
+      (assert (valid-api? config)
+              "Specify :api-url and :api-secret")
+      (assert (valid-datasource? config)
+              "Specify :datasource-id")
+      (-> config
+          fetch-datasource-config
+          download-datasource
+          extract-datasource
+          read-features
+          dump-ctx))))

--- a/app/datasource-import/src/teet/datasource_import/core.clj
+++ b/app/datasource-import/src/teet/datasource_import/core.clj
@@ -68,20 +68,19 @@
   (let [->label (property-pattern-fn (:label_pattern datasource))
         ->id (property-pattern-fn (:id_pattern datasource))]
     (doseq [features (partition-all 100 features)]
+      (print ".") (flush)
       (client/post
        (str api-url "/feature")
        {:headers {"Prefer" "resolution=merge-duplicates"
                   "Content-Type" "application/json"}
-        :body (let [body (cheshire/encode
-                          (for [{:keys [geometry attributes] :as f} features]
-                            ;; Feature as JSON
-                            {:datasource_id datasource-id
-                             :id (->id f)
-                             :label (->label f)
-                             :geometry geometry
-                             :properties attributes}))]
-                (spit "body.json" body)
-                body)}))
+        :body (cheshire/encode
+               (for [{:keys [geometry attributes] :as f} features]
+                 ;; Feature as JSON
+                 {:datasource_id datasource-id
+                  :id (->id f)
+                  :label (->label f)
+                  :geometry geometry
+                  :properties attributes}))}))
     ctx))
 
 (defn dump-ctx [ctx]

--- a/app/datasource-import/src/teet/datasource_import/shp.clj
+++ b/app/datasource-import/src/teet/datasource_import/shp.clj
@@ -13,9 +13,6 @@
   (-> file io/as-url
       ShapefileDataStore.))
 
-
-(def ds (shp-ds (io/file "/Users/tatuta/projects/mnt-teet/app/backend/Ehitusgeoloogia_uuringualad_shp/Ehitusgeoloogia_uuringualad_shp.shp")))
-
 (defn- to-iterator [^SimpleFeatureIterator it]
   (reify
     java.util.Iterator

--- a/app/datasource-import/src/teet/datasource_import/shp.clj
+++ b/app/datasource-import/src/teet/datasource_import/shp.clj
@@ -1,0 +1,71 @@
+(ns teet.datasource-import.shp
+  "Read ESRI Shapefile (.shp) features"
+  (:import (org.geotools.data.shapefile ShapefileDataStore)
+           (org.geotools.data.simple SimpleFeatureIterator)
+           (org.geotools.feature.simple SimpleFeatureImpl)
+           (org.opengis.feature.simple SimpleFeature)
+           (org.locationtech.jts.io WKBWriter))
+  (:require [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+(defn shp-ds [file]
+  (-> file io/as-url
+      ShapefileDataStore.))
+
+
+(def ds (shp-ds (io/file "/Users/tatuta/projects/mnt-teet/app/backend/Ehitusgeoloogia_uuringualad_shp/Ehitusgeoloogia_uuringualad_shp.shp")))
+
+(defn- to-iterator [^SimpleFeatureIterator it]
+  (reify
+    java.util.Iterator
+    (hasNext [_] (.hasNext it))
+    (next [_] (.next it))
+
+    java.lang.AutoCloseable
+    (close [_] (.close it))))
+
+(def ignore-attributes #{"the_geom"})
+
+(let [wkb-writer (WKBWriter.)]
+  (defn ->wkb [geometry]
+    (WKBWriter/bytesToHex
+     (.write wkb-writer geometry))))
+
+(defn feature-data [^SimpleFeatureImpl f]
+  (let [attr-names (set/difference
+                    (into #{}
+                          (map (comp str #(.getName %)))
+                          (.getProperties f))
+                    ignore-attributes)]
+    {:geometry (->wkb (doto (.getDefaultGeometry f)
+                        (.setSRID 3301)))
+     :attributes (into {}
+                       (map (fn [attr-name]
+                              [attr-name
+                               (->> attr-name
+                                    (.getProperty f)
+                                    .getValue)]))
+                       attr-names)}))
+
+(defn features [shp]
+  (->> shp
+       .getFeatureSource
+       .getFeatures
+       .features
+       to-iterator
+       iterator-seq
+       (map feature-data)))
+
+(defn read-features-from-path
+  "Takes a path that contains a shapefile (.shp and related files).
+  Returns a lazy sequence of parsed features."
+  [path]
+  (let [shp-file (->> path .toFile .listFiles
+                      seq (filter #(str/ends-with? (.getName %) ".shp"))
+                      first)]
+    (when-not shp-file
+      (throw (ex-info "Path doesn't contain an ESRI Shapefile. No file with .shp suffix found."
+                      {:path path})))
+    (println "Reading features from ESRI Shapefile:" (.getAbsolutePath shp-file))
+    (features (shp-ds shp-file))))

--- a/app/datasource-import/src/teet/datasource_import/shp.clj
+++ b/app/datasource-import/src/teet/datasource_import/shp.clj
@@ -27,7 +27,7 @@
 
 (def ignore-attributes #{"the_geom"})
 
-(let [wkb-writer (WKBWriter.)]
+(let [wkb-writer (WKBWriter. 2 true)]
   (defn ->wkb [geometry]
     (WKBWriter/bytesToHex
      (.write wkb-writer geometry))))
@@ -42,7 +42,7 @@
                         (.setSRID 3301)))
      :attributes (into {}
                        (map (fn [attr-name]
-                              [attr-name
+                              [(keyword attr-name)
                                (->> attr-name
                                     (.getProperty f)
                                     .getValue)]))

--- a/app/frontend/src/cljs/teet/localization.cljs
+++ b/app/frontend/src/cljs/teet/localization.cljs
@@ -9,7 +9,8 @@
             [clojure.string :as str]
             [cljs.reader :as reader]
             [postgrest-ui.display :as postgrest-display]
-            [alandipert.storage-atom :refer [local-storage]]))
+            [alandipert.storage-atom :refer [local-storage]]
+            [teet.util.string :as string]))
 
 (defn dev-mode? []
   (when-let [host (-> js/window .-location .-host)]
@@ -91,21 +92,12 @@
     :else
     (str part)))
 
-(defn- string-interpolation
-  "Replace parameter references in curly braces in the input string with values from parameters.
-  Example: \"Hello, {name}!\" would replace \"{name}\" with the :name parameter."
-  [string parameters]
-  (str/replace string
-               #"\{([^\}]+)\}"
-               (fn [[_ param-name]]
-                 (str
-                  (get parameters (keyword param-name)
-                       (str "[MISSING PARAMETER " param-name "]"))))))
+
 
 (defn- message [message-definition parameters]
   (cond
     (string? message-definition)
-    (string-interpolation message-definition parameters)
+    (string/interpolate message-definition parameters)
 
     (list? message-definition)
     (evaluate-list message-definition parameters)

--- a/db/src/main/resources/db/migration/V9__feature.sql
+++ b/db/src/main/resources/db/migration/V9__feature.sql
@@ -1,0 +1,35 @@
+-- Generic feature table
+
+CREATE TABLE teet.datasource (
+  id SERIAL PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL,
+  description TEXT,
+  url TEXT, -- URL to download features from
+  content_type TEXT, --  Datasource content type (like 'SHP')
+  label_pattern TEXT, -- Feature label pattern, may contain mustache references to properties
+  last_import_ts TIMESTAMPTZ, -- Timestamp of last import
+  last_import_hash TEXT -- SHA-256 content hash of last import
+
+);
+
+CREATE TABLE teet.feature (
+ id TEXT, -- feature id within a datasource
+ datasource_id INT REFERENCES teet.datasource (id),
+ type TEXT, -- Some feature type (internal to datasource)
+ label TEXT, -- Label to be shown on map (as tooltip)
+ geometry geometry(Geometry,3301),
+ properties JSON,
+
+ PRIMARY KEY(datasource_id, id)
+);
+
+CREATE INDEX feature_geom_idx ON teet.feature USING GIST (geometry);
+
+INSERT INTO teet.datasource (name, description, url, content_type, label_pattern)
+VALUES ('survey',
+        'Maa-amet survey data',
+        'https://geoportaal.maaamet.ee/docs/geoloogia/andmed/Ehitusgeoloogia_uuringualad_shp.zip',
+        'SHP',
+        '{NIMI}');
+
+GRANT SELECT ON teet.datasource TO teet_backend;

--- a/db/src/main/resources/db/migration/V9__feature.sql
+++ b/db/src/main/resources/db/migration/V9__feature.sql
@@ -34,3 +34,7 @@ VALUES ('survey',
         '{ID}', '{NIMI}');
 
 GRANT SELECT ON teet.datasource TO teet_backend;
+GRANT ALL PRIVILEGES ON teet.feature TO teet_backend;
+
+GRANT SELECT ON teet.datasource TO teet_user;
+GRANT SELECT ON teet.feature TO teet_user;

--- a/db/src/main/resources/db/migration/V9__feature.sql
+++ b/db/src/main/resources/db/migration/V9__feature.sql
@@ -6,6 +6,7 @@ CREATE TABLE teet.datasource (
   description TEXT,
   url TEXT, -- URL to download features from
   content_type TEXT, --  Datasource content type (like 'SHP')
+  id_pattern TEXT, -- Feature id pattern, may contain mustache refs to properties
   label_pattern TEXT, -- Feature label pattern, may contain mustache references to properties
   last_import_ts TIMESTAMPTZ, -- Timestamp of last import
   last_import_hash TEXT -- SHA-256 content hash of last import
@@ -25,11 +26,11 @@ CREATE TABLE teet.feature (
 
 CREATE INDEX feature_geom_idx ON teet.feature USING GIST (geometry);
 
-INSERT INTO teet.datasource (name, description, url, content_type, label_pattern)
+INSERT INTO teet.datasource (name, description, url, content_type, id_pattern, label_pattern)
 VALUES ('survey',
         'Maa-amet survey data',
         'https://geoportaal.maaamet.ee/docs/geoloogia/andmed/Ehitusgeoloogia_uuringualad_shp.zip',
         'SHP',
-        '{NIMI}');
+        '{ID}', '{NIMI}');
 
 GRANT SELECT ON teet.datasource TO teet_backend;


### PR DESCRIPTION
Added a more generic way to store map datasources. The definition of a datasource (with information about how to fetch it) is in the `datasource` table. Features imported from a datasource are in `feature` table.

Added a tool to import a datasource's features using the PostgREST API. 

The periodical/automated running of datasource import, along with hash/changed checking is out of scope for this issue, but I added the required columns for that as well.