### PR TITLE
Frontend version desync / deployment break detection: detect any change to versions, don't try to track git revisions

### DIFF
--- a/app/frontend/src/cljs/teet/common/common_controller.cljs
+++ b/app/frontend/src/cljs/teet/common/common_controller.cljs
@@ -389,7 +389,14 @@
                  (reset! version-seen-on-startup commit))
                
                (js/setTimeout #(poll-version e!) poll-timeout-ms)
-               (when (and (some? commit) (not= commit @version-seen-on-startup))
+               (cond
+                 (= status "deploying")
+                 (e! (snackbar-controller/->OpenSnackBarWithOptions
+                      {:message (tr [:warning :deploying])
+                       :variant :warning
+                       :hide-duration nil}))
+                 
+                 (and (some? commit) (not= commit @version-seen-on-startup))
                  (e! (snackbar-controller/->OpenSnackBarWithOptions
                       {:message (tr [:warning :version-mismatch])
                        :variant :warning

--- a/app/frontend/src/cljs/teet/common/common_controller.cljs
+++ b/app/frontend/src/cljs/teet/common/common_controller.cljs
@@ -107,7 +107,6 @@
     (-> err ex-data :error)))
 
 (defn default-server-error-handler [err app]
-  (log/debug "snack-bar open called -> :snackbar :open? should go true in appdb")
   (snackbar-controller/open-snack-bar app (tr-or [:error (-> err ex-data :error)]
                                                  [:error :server-error]
                                                  "error")
@@ -346,7 +345,6 @@
                         10000)
       (.then #(.json %))
       (.then (fn [json-response]
-               (log/debug "fetch-deploy-status resolving")
                (js/Promise.resolve (js->clj json-response))))))
 
 ;; Check deploy status, show corresponding snackbar message
@@ -372,7 +370,7 @@
   (t/fx app {:tuck.effect/type :deploy-status
              :result-event ->DeployStatusResponse}))
 
-(def ^:private poll-timeout-ms 8000)
+(def ^:private poll-timeout-ms 30000)
 
 (defonce version-seen-on-startup (atom nil))
 (defn poll-version
@@ -380,10 +378,8 @@
   currently deployed. If not, shows a warning that a new version is
   being, or has been, deployed."
   [e!]
-  (log/debug "poll-version")
   (-> (fetch-deploy-status)
       (.then (fn [{:strs [commit status]}]
-               (log/debug "deploy-status cb, commit=" commit)
                (when (and (some? commit)
                           (nil? @version-seen-on-startup))
                  (reset! version-seen-on-startup commit))

--- a/app/frontend/src/cljs/teet/main.cljs
+++ b/app/frontend/src/cljs/teet/main.cljs
@@ -40,7 +40,6 @@
 
 (defn main-view [e! _]
   (log/hook-onerror! e!)
-  (log/debug "main-view calling poll-version")
   (poll-version e!)
   (e! (login-controller/->CheckExistingSession))
   (fn [e! {:keys [page user navigation quick-search snackbar] :as app}]

--- a/app/frontend/src/cljs/teet/main.cljs
+++ b/app/frontend/src/cljs/teet/main.cljs
@@ -16,7 +16,7 @@
             [tuck.core :as t]
             [teet.theme.theme-provider :as theme]
             [teet.snackbar.snackbar-view :as snackbar]
-            [teet.common.common-controller :refer [when-feature]]
+            [teet.common.common-controller :refer [when-feature poll-version]]
 
     ;; Import view namespaces
             teet.projects.projects-view
@@ -40,8 +40,8 @@
 
 (defn main-view [e! _]
   (log/hook-onerror! e!)
-  ;; TODO: Enable after getting proper sha from backend
-  ;; (poll-version e!)
+  (log/debug "main-view calling poll-version")
+  (poll-version e!)
   (e! (login-controller/->CheckExistingSession))
   (fn [e! {:keys [page user navigation quick-search snackbar] :as app}]
     (let [nav-open? (boolean (:open? navigation))]

--- a/app/frontend/src/cljs/teet/user/user_controller.cljs
+++ b/app/frontend/src/cljs/teet/user/user_controller.cljs
@@ -17,3 +17,4 @@
 (defn when-role [role component]
   (when (has-role? role)
     component))
+


### PR DESCRIPTION
Based on Ville's idea from yesterday