### PR TITLE
Keep track of deleted status of geo features

### DIFF
--- a/app/backend/src/clj/teet/integration/x_road/property_registry.clj
+++ b/app/backend/src/clj/teet/integration/x_road/property_registry.clj
@@ -29,6 +29,7 @@
      [:kr:request
       [:kin:jao_nr "0,1,2,3,4"]
       [:kin:kande_kehtivus "1"]
+      ;; [:kin:kande_kehtivus "0"] ;; to also see not in force items
       [:kin:kasutajanimi]
       [:kin:parool]
       [:kin:registriosa_nr registriosa-nr]]])))
@@ -185,7 +186,8 @@
                    (mapv cell-to-text (z/xml-> row :td)))]
       (if (or (empty? parsed)
               (not= 2 (count (first parsed))))
-        (log/error "couldn't parse non-empty kande_tekst without table:" kande-tekst)
+        (when (not= "<root/>" kande-tekst)
+          (log/error "couldn't parse non-empty kande_tekst without table or <root/>:" kande-tekst))
         parsed))))
 
 

--- a/app/datasource-import/src/teet/datasource_import/core.clj
+++ b/app/datasource-import/src/teet/datasource_import/core.clj
@@ -61,6 +61,10 @@
   ctx)
 
 (defn existing-features-ids [{:keys [api-url api-secret] :as ctx}]
+  ;; memory usage note:
+  ;; (clj-memory-meter.core/measure (existing-features-ids (make-config ["example-config.edn"])))
+  ;; gives 97 kB/1000 rows and 183 MB for the 2M rows in current db as of this writing, leaving
+  ;; a lot of headroom, but conceivably could outgrow the smallest 3GB CodeBuild VM some day.
   (let [get-url (str api-url "/feature?select=id,datasource_id")
         resp (client/get get-url
                          {:headers (merge (auth-headers {:api-secret api-secret})
@@ -118,7 +122,7 @@
                   :deleted false
                   :properties attributes}))}))
     (when (not-empty deleted?)
-      (println "marking features absent from import file as deleted")
+      (print "\nMarking features absent from import file as deleted.\n")
       (client/post
        (str api-url "/feature")
        {:headers (merge

--- a/app/datasource-import/src/teet/datasource_import/core.clj
+++ b/app/datasource-import/src/teet/datasource_import/core.clj
@@ -118,7 +118,7 @@
                   :deleted false
                   :properties attributes}))}))
     (when (not-empty deleted?)
-      (print "marking features absent from import file as deleted")
+      (println "marking features absent from import file as deleted")
       (client/post
        (str api-url "/feature")
        {:headers (merge

--- a/db/src/main/resources/db/migration/V14__feature_deleted_column.sql
+++ b/db/src/main/resources/db/migration/V14__feature_deleted_column.sql
@@ -1,0 +1,6 @@
+-- datasource-import now first queries the db for the existing IDs and sets deleted for any feature ID that doesn't appear in the latest imported shp file
+
+ALTER TABLE teet.feature
+  ADD COLUMN deleted BOOLEAN
+  DEFAULT FALSE;
+


### PR DESCRIPTION
This is done by checking which feature IDs have been previously
imported but are missing in newly imported SHP files.