### PR TITLE
Add :file/upload-complete? and only return completed files

### DIFF
--- a/app/backend/resources/schema.edn
+++ b/app/backend/resources/schema.edn
@@ -954,7 +954,7 @@
            :db/cardinality :db.cardinality/one
            :db/unique :db.unique/identity
            :db/doc "Ensure there is only one owner-comments for an owner per project"}]]}
- 
+
  {:db/ident :migration/file-pos-number
   :txes [[{:db/ident :file/pos-number
            :db/valueType :db.type/long
@@ -985,4 +985,10 @@
            :db/valueType   :db.type/ref
            :db/doc         "User who manages the activity"}]]}
 
- ]
+ {:db/ident :migration/file-upload-status
+  :txes [[{:db/ident :file/upload-complete?
+           :db/cardinality :db.cardinality/one
+           :db/valueType :db.type/boolean
+           :db/doc "Set to true when upload is complete and file exists in S3"}]
+
+         teet.migration.file-upload-complete/existing-files-upload-complete]}]

--- a/app/backend/src/clj/teet/file/file_commands.clj
+++ b/app/backend/src/clj/teet/file/file_commands.clj
@@ -71,6 +71,18 @@
                 ;; Take part after last underscore to skip over invalid metadata
                 (last (str/split n #"_")))))))
 
+(defcommand :file/upload-complete
+  {:doc "Mark file upload as complete"
+   :context {:keys [conn user db]}
+   :payload {id :db/id}
+   :pre [(file-db/own-file? db user id)]
+   ;; No need to check extra authorization again, as we check pre condition that this
+   ;; is the user's own uploaded file
+   :project-id nil
+   :authorization {}
+   :transact [{:db/id id
+               :file/upload-complete? true}]})
+
 (defcommand :file/upload
   {:doc "Upload new file to task."
    :context {:keys [conn user db]}

--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -51,6 +51,7 @@
                     (d/q '[:find (pull ?f [*
                                            {:file/previous-version [:db/id]}
                                            {:meta/creator [:user/id :user/family-name :user/given-name]}])
+                           :where [?f :file/upload-complete? true]
                            :in $ [?f ...]] db file-ids))
         ;; Group files to first versions and next versions
         {next-versions true
@@ -94,4 +95,3 @@
   [db project-id pos-number]
   ;; Could be improved with some distinct query magic to query only the count
   (count (files-by-project-and-pos-number db project-id pos-number)))
-


### PR DESCRIPTION

- Add `:file/upload-complete?` attribute
- Mark file upload as complete after the S3 PUT request is done
- Only return upload complete files in file listing query
