### PR TITLE
TEET-786 continued: Remove mime types

### DIFF
--- a/app/backend/resources/datomic/ion-config.edn
+++ b/app/backend/resources/datomic/ion-config.edn
@@ -1,4 +1,5 @@
-{:allow [teet.meeting.meeting-tx/add-participation]
+{:allow [teet.meeting.meeting-tx/add-participation
+         teet.file.file-model/image-suffix?]
  :lambdas {:query
            {:fn teet.db-api.db-api-ion/db-api-query
             :integration :api-gateway/proxy

--- a/app/backend/src/clj/teet/ags/ags_import.clj
+++ b/app/backend/src/clj/teet/ags/ags_import.clj
@@ -24,7 +24,7 @@
          :default-path [:ags-files]}}
   (mapv first
         (d/q
-         '[:find (pull ?file [:db/id :file/name :file/size :file/type])
+         '[:find (pull ?file [:db/id :file/name :file/size])
            :where
            [?project-id :thk.project/lifecycles ?lifecycle]
            [?lifecycle :thk.lifecycle/activities ?activity]

--- a/app/backend/src/clj/teet/comment/comment_commands.clj
+++ b/app/backend/src/clj/teet/comment/comment_commands.clj
@@ -26,8 +26,8 @@
               (d/q '[:find ?c
                      :where
                      [?c :meta/creator ?user]
-                     [?c :file/type ?type]
-                     [(.startsWith ^String ?type "image/")]
+                     [?c :file/name ?name]
+                     [(teet.file.file-model/image-suffix? ?name)]
                      :in $ $user [?c ...]]
                    db
                    (user-model/user-ref user)

--- a/app/backend/src/clj/teet/comment/comment_commands.clj
+++ b/app/backend/src/clj/teet/comment/comment_commands.clj
@@ -12,7 +12,6 @@
             [teet.permission.permission-db :as permission-db]
             [teet.notification.notification-db :as notification-db]
             [teet.user.user-model :as user-model]
-            [teet.util.collection :as cu]
             [teet.util.datomic :as du])
   (:import (java.util Date)))
 

--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -87,7 +87,7 @@
                        (comment-counts-by-file (:db/id %))
                        {:file-seen/seen-at (seen-at-by-file (:db/id %))})
                first)
-         (d/q '[:find (pull ?f [:db/id :file/name :meta/deleted? :file/version :file/size :file/type :file/status
+         (d/q '[:find (pull ?f [:db/id :file/name :meta/deleted? :file/version :file/size :file/status
                                 {:file/previous-version [:db/id]}
                                 {:meta/creator [:user/id :user/family-name :user/given-name]}])
                 :where

--- a/app/backend/test/teet/comment_commands_test.clj
+++ b/app/backend/test/teet/comment_commands_test.clj
@@ -233,8 +233,7 @@
                 teet.integration.integration-s3/presigned-url (constantly "url")]
     (->> (tu/local-command :file/upload {:task-id (tu/get-data :task-id)
                                          :file {:file/name "land_deals.pdf"
-                                                :file/size 666
-                                                :file/type "application/pdf"}})
+                                                :file/size 666}})
          :file
          (tu/store-data! :file)))
 

--- a/app/backend/test/teet/file/file_commands_test.clj
+++ b/app/backend/test/teet/file/file_commands_test.clj
@@ -4,14 +4,14 @@
 
 (deftest validate-document
   (testing "too large files are invalid"
-    (is (= (:error (file-model/validate-file {:file/type "image/png"
-                                                     :file/size (* 1024 1024 3001)}))
+    (is (= (:error (file-model/validate-file {:file/name "image.png"
+                                              :file/size (* 1024 1024 3001)}))
            :file-too-large)))
-  (testing "files of illegal type are invalid"
-    (is (= (:error (file-model/validate-file {:file/type "application/nonsense"
-                                                  :file/size 1024}))
+  (testing "files with illegal type suffix are invalid"
+    (is (= (:error (file-model/validate-file {:file/name "myfile.nonsense"
+                                              :file/size 1024}))
            :file-type-not-allowed)))
   (testing "other files are valid"
     (is (nil? (file-model/validate-file
-                {:file/type (rand-nth (vec file-model/upload-allowed-file-types))
-                 :file/size (rand (inc file-model/upload-max-file-size))})))))
+               {:file/name (str "myfile." (rand-nth (seq file-model/upload-allowed-file-suffixes)))
+                :file/size (rand (inc file-model/upload-max-file-size))})))))

--- a/app/backend/test/teet/file/file_model_test.clj
+++ b/app/backend/test/teet/file/file_model_test.clj
@@ -1,8 +1,0 @@
-(ns teet.file.file-model-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [teet.file.file-model :as file-model]))
-
-(deftest type-by-suffix
-  (testing "`:type` of returned file map is determined by file name suffix"
-    (is (= (file-model/type-by-suffix {:file/name "image.jpg" :file/type "image/ecw"})
-           {:file/name "image.jpg" :file/type "image/jpeg"}))))

--- a/app/common/src/cljc/teet/file/file_spec.cljc
+++ b/app/common/src/cljc/teet/file/file_spec.cljc
@@ -7,13 +7,12 @@
 #?(:cljs
    (defn file-info [^js/File f]
      {:file/name (.-name f)
-      :file/size (.-size f)
-      :file/type (.-type f)}))
+      :file/size (.-size f)}))
 
 (s/def ::task-id integer?)
 (s/def ::file-id integer?)
 (s/def ::previous-version-id integer?)
-(s/def ::file (s/keys :req [:file/name :file/size :file/type]))
+(s/def ::file (s/keys :req [:file/name :file/size]))
 
 (s/def :file/upload (s/keys :req-un [::task-id ::file]
                             :opt-un [::previous-version-id]))
@@ -23,7 +22,6 @@
 (s/def :file/download-file (s/keys :req-un [::file-id]))
 (s/def :file/status keyword?)
 (s/def :file/name (s/and string? (complement str/blank?)))
-(s/def :file/type string?)
 (s/def :file/size integer?)
 (s/def :file/description (s/and string? (complement str/blank?)))
 (s/def :file/category keyword?)

--- a/app/common/src/cljc/teet/task/task_spec.cljc
+++ b/app/common/src/cljc/teet/task/task_spec.cljc
@@ -31,10 +31,9 @@
 
 (s/def :task/add-files (s/keys :req [:task/files]))
 
-(s/def :task/file (s/and (s/keys :req [:file/type
-                                       :file/name
+(s/def :task/file (s/and (s/keys :req [:file/name
                                        :file/size])
-                         #(nil? (file-model/validate-file (file-model/type-by-suffix %)))))
+                         #(nil? (file-model/validate-file %))))
 
 (s/def :task/new-comment-form (s/keys :req [:comment/comment]))
 

--- a/app/frontend/src/cljs/teet/file/file_view.cljs
+++ b/app/frontend/src/cljs/teet/file/file_view.cljs
@@ -87,22 +87,6 @@
                :href (common-controller/query-url :file/download-file {:file-id id})}
          [icons/file-cloud-download]]])]))
 
-(defn- other-version-row
-  [{id :db/id
-    :file/keys [name version status]
-    :meta/keys [created-at creator]
-    :as _file}]
-  [:div.file-row {:class [(<class common-styles/flex-row) (<class common-styles/margin-bottom 0.5)]}
-   [:div.file-row-name {:class (<class common-styles/flex-table-column-style 55)}
-    [url/Link {:page :file :params {:file id}}
-     name]]
-   [:div.file-row-version {:class (<class common-styles/flex-table-column-style 10 :center)}
-    [:span (str "V" version)]]
-   [:div.file-row-status {:class (<class common-styles/flex-table-column-style 10 :center)}
-    [:span (tr-enum status)]]
-   [:div.file-row-date {:class (<class common-styles/flex-table-column-style 25 :flex-end)}
-    [:span (format/date created-at)]]])
-
 (def ^:private sorters
   {"meta/created-at" [(juxt :meta/created-at :file/name) >]
    "file/name"       [:file/name <]

--- a/app/frontend/src/cljs/teet/task/task_view.cljs
+++ b/app/frontend/src/cljs/teet/task/task_view.cljs
@@ -175,8 +175,8 @@
       ^{:attribute :task/files
         :validate (fn [array-files]
                     (->> array-files
-                         (map (comp file-model/upload-allowed-file-types
-                                    :file/type
+                         (map (comp file-model/valid-suffix?
+                                    :file/name
                                     file-upload/files-field-entry))
                          (some nil?)))}
       [file-upload/files-field {}]]

--- a/app/frontend/src/cljs/teet/task/task_view.cljs
+++ b/app/frontend/src/cljs/teet/task/task_view.cljs
@@ -178,7 +178,7 @@
                          (map (comp file-model/valid-suffix?
                                     :file/name
                                     file-upload/files-field-entry))
-                         (some nil?)))}
+                         (some false?)))}
       [file-upload/files-field {}]]
      (when upload-progress
        [LinearProgress {:variant "determinate"

--- a/app/frontend/src/cljs/teet/ui/file_upload.cljs
+++ b/app/frontend/src/cljs/teet/ui/file_upload.cljs
@@ -1,7 +1,8 @@
 (ns teet.ui.file-upload
-  (:require [herb.core :refer [<class]]
+  (:require [clojure.string :as str]
+            [herb.core :refer [<class]]
             [reagent.core :as r]
-            [teet.ui.material-ui :refer [Button IconButton List ListItem
+            [teet.ui.material-ui :refer [IconButton List ListItem
                                          ListItemText ListItemSecondaryAction]]
             [teet.ui.text-field :refer [TextField]]
             [teet.theme.theme-colors :as theme-colors]
@@ -145,14 +146,13 @@
            {:border (str "solid 1px " theme-colors/error)})))                 ;;This should also use material ui theme.error
 
 (defn file-info
-  [{:file/keys [name type size] :as _file} invalid-file-type? file-too-large?]
+  [{:file/keys [name size] :as _file} invalid-file-type? file-too-large?]
   [:<>
    (into [:span (merge {} (when invalid-file-type?
-                            {:style {:color theme-colors/error}}))
-          (str (or (not-empty type)
-                   (file-model/filename->suffix name)))]
+                            {:style {:color theme-colors/error}}))]
          (when invalid-file-type?
-           [" "
+           [(str/upper-case (file-model/filename->suffix name))
+            " "
             [:a {:target "_blank"
                  :href "https://confluence.mkm.ee/pages/viewpage.action?spaceKey=TEET&title=TEET+File+format+list"}
              (tr [:document :invalid-file-type])]]))
@@ -166,8 +166,7 @@
 (defn files-field-entry [file-entry]
   (-> file-entry
       :file-object
-      file-model/file-info
-      file-model/type-by-suffix))
+      file-model/file-info))
 
 (defn files-field [{:keys [value on-change error]}]
   [:div {:class (<class files-field-style error)}

--- a/app/frontend/src/cljs/teet/ui/file_upload.cljs
+++ b/app/frontend/src/cljs/teet/ui/file_upload.cljs
@@ -178,9 +178,9 @@
       (fn [i ^js/File file]
         ^{:key i}
         [ListItem {}
-         (let [{:file/keys [type name size] :as file}
+         (let [{:file/keys [name size] :as file}
                (files-field-entry file)
-               invalid-file-type? (not (file-model/upload-allowed-file-types type))
+               invalid-file-type? (not (file-model/valid-suffix? name))
                file-too-large? (> size file-model/upload-max-file-size)]
            [ListItemText (merge
                           {:primary name


### PR DESCRIPTION
This PR removes mime type handling from the codebase. File suffixes are used instead.