### PR TITLE
TEET-647 attachments to meeting agenda

### DIFF
--- a/app/backend/resources/schema.edn
+++ b/app/backend/resources/schema.edn
@@ -1137,4 +1137,10 @@
            :db/valueType :db.type/instant
            :db/cardinality :db.cardinality/one
            :db/doc "Timestamp for when the meetings calendar invitations were sent"}]]}
+
+ {:db/ident :migration/file-attached-to
+  :txes [[{:db/ident :file/attached-to
+           :db/valueType :db.type/ref
+           :db/cardinality :db.cardinality/many
+           :db/doc "Entities this file is attached to."}]]}
  ]

--- a/app/backend/src/clj/teet/file/file_commands.clj
+++ b/app/backend/src/clj/teet/file/file_commands.clj
@@ -49,9 +49,7 @@
 
          ^{:error :attach-pre-check-failed}
          (or (nil? attach-to)
-             (and (vector? attach-to)
-                  (= 2 (count attach-to))
-                  (file-db/attach-to db user file (first attach-to) (second attach-to))))]}
+             (file-db/attach-to db user file attach-to))]}
   (log/debug "upload-attachment: got project-id" project-id)
 
   (let [key (new-file-key file)
@@ -60,8 +58,7 @@
                          :file/s3-key key}
                         (when attach-to
                           {:file/attached-to (file-db/attach-to db user file
-                                                                (first attach-to)
-                                                                (second attach-to))})
+                                                                attach-to)})
                         (creation-meta user))])
         file-id (get-in res [:tempids "new-file"])]
 
@@ -146,10 +143,6 @@
           (catch Exception e
             (log/warn e "Unable to create S3 presigned URL")
             (throw e))))))
-
-(defcommand :file/upload-to-meeting-agenda
-  {:doc "Upload file attachment to meeting agenda"
-   :context })
 
 (defcommand :file/delete
   {:doc "Delete file"

--- a/app/backend/src/clj/teet/file/file_commands.clj
+++ b/app/backend/src/clj/teet/file/file_commands.clj
@@ -75,7 +75,8 @@
    :pre [(or (and attached-to
                   (file-db/allow-delete-attachment? db user
                                                     file-id
-                                                    attached-to))
+                                                    attached-to)
+                  (file-db/file-is-attached-to? db file-id attached-to))
              (file-db/own-file? db user file-id))]
    :transact [(deletion-tx user file-id)]})
 

--- a/app/backend/src/clj/teet/file/file_commands.clj
+++ b/app/backend/src/clj/teet/file/file_commands.clj
@@ -69,10 +69,14 @@
 (defcommand :file/delete-attachment
   {:doc "Delete an attachment"
    :context {:keys [user db]}
-   :payload {:keys [file-id]}
+   :payload {:keys [file-id attached-to]}
    :project-id nil
    :authorization {}
-   :pre [(file-db/own-file? db user file-id)]
+   :pre [(or (and attached-to
+                  (file-db/allow-delete-attachment? db user
+                                                    file-id
+                                                    attached-to))
+             (file-db/own-file? db user file-id))]
    :transact [(deletion-tx user file-id)]})
 
 (defn- file-with-metadata [{:file/keys [name] :as file}]

--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -35,6 +35,14 @@
   (fn [_db _user attach]
     (first (check-attach-definition attach))))
 
+(defmulti allow-delete-attachment?
+  "Check preconditions and premissions for deleting an attached file
+  to a given entity.
+
+  Default behaviour is to disallow."
+  (fn [_db _user _file-id attach]
+    (first (check-attach-definition attach))))
+
 (defmethod attach-to :default [_db user _file [entity-type entity-id]]
   (log/info "Disallow attaching file to " entity-type " with id " entity-id
             " for user " user)
@@ -44,6 +52,12 @@
   [_db user [entity-type entity-id]]
   (log/info "Disallow downloading attachments to " entity-type
             " with id " entity-id " for user " user))
+
+(defmethod allow-delete-attachment? :default
+  [_db user file-id [entity-type entity-id]]
+  (log/info "Disallow deleting attachment " file-id " to "
+            entity-type " with id " entity-id " for user " user)
+  false)
 
 (defn own-file? [db user file-id]
   (boolean

--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -2,7 +2,24 @@
   "File queries"
   (:require [datomic.client.api :as d]
             [teet.user.user-model :as user-model]
-            [teet.comment.comment-db :as comment-db]))
+            [teet.comment.comment-db :as comment-db]
+            [teet.log :as log]))
+
+(defmulti attach-to
+  "Check preconditions and permissions for attaching file to
+  entity of given type and id for the user.
+
+  Return eid to attach to if attaching is allowed, nil if not.
+  May also throw an exception with :error key in the exception.
+
+  Default behaviour is to disallow."
+  (fn [_db _user _file entity-type _entity-id]
+    entity-type))
+
+(defmethod attach-to :default [_db user _file entity-type entity-id]
+  (log/info "Disallow attaching file to " entity-type " with id " entity-id
+            " for user " user)
+  nil)
 
 (defn own-file? [db user file-id]
   (boolean

--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -59,6 +59,15 @@
             entity-type " with id " entity-id " for user " user)
   false)
 
+(defn file-is-attached-to? [db file-id attach]
+  (and (valid-attach-definition? attach)
+       (boolean
+        (seq
+         (d/q '[:find ?eid
+                :where [?f :file/attached-to ?eid]
+                :in $ ?f ?eid]
+              db file-id (second attach))))))
+
 (defn own-file? [db user file-id]
   (boolean
    (ffirst

--- a/app/backend/src/clj/teet/file/file_queries.clj
+++ b/app/backend/src/clj/teet/file/file_queries.clj
@@ -36,9 +36,12 @@
 (defquery :file/download-attachment
   {:doc "Download comment attachment"
    :context {:keys [db user]}
-   :args {:keys [file-id comment-id]}
+   :args {:keys [file-id attached-to comment-id]}
    :pre [(or (and comment-id
                   (file-db/file-is-attached-to-comment? db file-id comment-id))
+             (and attached-to
+                  (file-db/allow-download-attachments? db user attached-to))
+
              (file-db/own-file? db user file-id))]
    :project-id (when comment-id
                  (project-db/comment-project-id db comment-id))

--- a/app/backend/src/clj/teet/file/file_queries.clj
+++ b/app/backend/src/clj/teet/file/file_queries.clj
@@ -40,7 +40,8 @@
    :pre [(or (and comment-id
                   (file-db/file-is-attached-to-comment? db file-id comment-id))
              (and attached-to
-                  (file-db/allow-download-attachments? db user attached-to))
+                  (file-db/allow-download-attachments? db user attached-to)
+                  (file-db/file-is-attached-to? db file-id attached-to))
 
              (file-db/own-file? db user file-id))]
    :project-id (when comment-id

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -16,11 +16,18 @@
   (:import (java.util Date)))
 
 (defmethod file-db/attach-to :meeting-agenda
-  [db user _file _ meeting-agenda-id]
-  (let [meeting (get-in (du/entity db meeting-agenda-id)
-                        [:meeting/_agenda :db/id])]
-    (when (meeting-db/user-is-organizer-or-reviewer? db user meeting)
-      meeting-agenda-id)))
+  [db user _file [_ meeting-agenda-id]]
+  (when (meeting-db/user-is-organizer-or-reviewer?
+         db user
+         (get-in (du/entity db meeting-agenda-id)
+                 [:meeting/_agenda :db/id]))
+    meeting-agenda-id))
+
+(defmethod file-db/allow-download-attachments? :meeting-agenda
+  [db user [_ meeting-agenda-id]]
+  (meeting-db/user-is-participating?
+   db user (get-in (du/entity db meeting-agenda-id)
+                   [:meeting/_agenda :db/id])))
 
 ;; TODO query all activity meetings
 ;; matching name found

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -29,6 +29,14 @@
    db user (get-in (du/entity db meeting-agenda-id)
                    [:meeting/_agenda :db/id])))
 
+(defmethod file-db/allow-delete-attachment? :meeting-agenda
+  [db user _file-id [_ meeting-agenda-id]]
+  (when (meeting-db/user-is-organizer-or-reviewer?
+         db user
+         (get-in (du/entity db meeting-agenda-id)
+                 [:meeting/_agenda :db/id]))
+    meeting-agenda-id))
+
 ;; TODO query all activity meetings
 ;; matching name found
 ;; TODO try tx function

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -1,14 +1,11 @@
 (ns teet.meeting.meeting-commands
-  (:require [clojure.spec.alpha :as s]
-            [datomic.client.api :as d]
+  (:require [datomic.client.api :as d]
             [teet.db-api.core :as db-api :refer [defcommand tx-ret]]
             [teet.meta.meta-model :as meta-model]
-            [teet.notification.notification-db :as notification-db]
+            [teet.file.file-db :as file-db]
             [teet.project.project-db :as project-db]
             teet.meeting.meeting-specs
             [teet.util.datomic :as du]
-            [teet.util.collection :as cu]
-            [teet.user.user-model :as user-model]
             [teet.meeting.meeting-db :as meeting-db]
             [teet.meeting.meeting-ics :as meeting-ics]
             [teet.integration.integration-email :as integration-email]
@@ -17,6 +14,13 @@
             [teet.log :as log]
             [clojure.string :as str])
   (:import (java.util Date)))
+
+(defmethod file-db/attach-to :meeting-agenda
+  [db user _file _ meeting-agenda-id]
+  (let [meeting (get-in (du/entity db meeting-agenda-id)
+                        [:meeting/_agenda :db/id])]
+    (when (meeting-db/user-is-organizer-or-reviewer? db user meeting)
+      meeting-agenda-id)))
 
 ;; TODO query all activity meetings
 ;; matching name found

--- a/app/backend/src/clj/teet/meeting/meeting_queries.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_queries.clj
@@ -2,7 +2,6 @@
   (:require [teet.project.project-db :as project-db]
             [teet.db-api.core :refer [defquery]]
             [teet.meta.meta-query :as meta-query]
-            [teet.project.project-model :as project-model]
             [teet.meeting.meeting-db :as meeting-db]
             [teet.user.user-model :as user-model]
             [datomic.client.api :as d]))
@@ -54,7 +53,8 @@
                                              :meeting.agenda/topic
                                              :meeting.agenda/body
                                              {:meeting.agenda/decisions [:db/id :meeting.decision/body]}
-                                             {:meeting.agenda/responsible ~user-model/user-listing-attributes}]}
+                                             {:meeting.agenda/responsible ~user-model/user-listing-attributes}
+                                             {:file/_attached-to [:db/id :file/name]}]}
                            {:participation/_in
                             [:db/id
                              :participation/role

--- a/app/frontend/src/cljs/teet/file/file_controller.cljs
+++ b/app/frontend/src/cljs/teet/file/file_controller.cljs
@@ -43,12 +43,15 @@
                            (common-controller/->Navigate :activity-task (dissoc params :file) {}))}))
 
   DeleteAttachment
-  (process-event [{:keys [file-id on-success-event]} app]
+  (process-event [{:keys [file-id on-success-event attached-to success-message]} app]
     (t/fx app
           {:tuck.effect/type :command!
            :command :file/delete-attachment
-           :payload {:file-id file-id}
-           :result-event on-success-event}))
+           :payload {:file-id file-id
+                     :attached-to attached-to}
+           :result-event (or on-success-event
+                             common-controller/->Refresh)
+           :success-message success-message}))
 
   AddFilesToTask
   (process-event [{:keys [files on-success]} app]

--- a/app/frontend/src/cljs/teet/file/file_controller.cljs
+++ b/app/frontend/src/cljs/teet/file/file_controller.cljs
@@ -90,7 +90,8 @@
                                      :on-success (->UploadSuccess (:db/id file))})))}))
 
   UploadFiles
-  (process-event [{:keys [files project-id task-id on-success progress-increment attachment?
+  (process-event [{:keys [files project-id task-id on-success progress-increment
+                          attachment? attach-to
                           file-results]
                    :as event} app]
     (if-let [file (first files)]
@@ -108,7 +109,8 @@
                                                (when (not (str/blank? pos))
                                                  {:file/pos-number (js/parseInt pos)})))}
                                (if attachment?
-                                 {:project-id project-id}
+                                 {:project-id project-id
+                                  :attach-to attach-to}
                                  {:task-id task-id}))
                :result-event (fn [result]
                                (map->UploadFileUrlReceived

--- a/app/frontend/src/cljs/teet/file/file_view.cljs
+++ b/app/frontend/src/cljs/teet/file/file_view.cljs
@@ -43,7 +43,7 @@
       [name ""])))
 
 (defn- file-row
-  [{:keys [link-download? no-link? attached-to actions? comment-action columns]
+  [{:keys [link-download? no-link? attached-to actions? comment-action columns delete-action]
     :or {link-download? false
          actions? true
          columns (constantly true)}}
@@ -111,7 +111,12 @@
                          {:file-id id}
                          (when attached-to
                            {:attached-to attached-to})))}
-           [icons/file-cloud-download]])])]))
+           [icons/file-cloud-download]])
+
+        (when (columns :delete)
+          [buttons/delete-button-with-confirm
+           {:action #(delete-action file)
+            :trashcan? true}])])]))
 
 (def ^:private sorters
   {"meta/created-at" [(juxt :meta/created-at :file/name) >]

--- a/app/frontend/src/cljs/teet/file/file_view.cljs
+++ b/app/frontend/src/cljs/teet/file/file_view.cljs
@@ -113,7 +113,7 @@
                            {:attached-to attached-to})))}
            [icons/file-cloud-download]])
 
-        (when (columns :delete)
+        (when (and (columns :delete) delete-action)
           [buttons/delete-button-with-confirm
            {:action #(delete-action file)
             :trashcan? true}])])]))

--- a/app/frontend/src/cljs/teet/file/file_view.cljs
+++ b/app/frontend/src/cljs/teet/file/file_view.cljs
@@ -284,11 +284,13 @@
          (when (and can-replace-file?
                     (nil? latest-file)
                     (du/enum= :file.status/draft (:file/status file)))
-           [:div
-            [file-upload/FileUploadButton {:on-drop (e! file-controller/->UploadNewVersion file)
-                                           :color :secondary
-                                           :icon [icons/file-cloud-upload]
-                                           :multiple? false}
+           [:div#file-details-upload-replacement
+            [file-upload/FileUploadButton
+             {:on-drop (e! file-controller/->UploadNewVersion file)
+              :drag-container-id "file-details-upload-replacement"
+              :color :secondary
+              :icon [icons/file-cloud-upload]
+              :multiple? false}
              (tr [:file :upload-new-version])]])])
       [buttons/button-primary {:element "a"
                                :href (common-controller/query-url :file/download-file

--- a/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
+++ b/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
@@ -364,8 +364,10 @@
 
       [typography/BoldGreyText (tr [:common :files])]
       [file-view/file-table {:filtering? false
-                             :actions? false
-                             :columns #{:suffix}} files]
+                             :actions? true
+                             :no-link? true
+                             :attached-to [:meeting-agenda id]
+                             :columns #{:suffix :download}} files]
 
       [authorization-context/when-authorized :edit-meeting
        [file-upload/FileUploadButton

--- a/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
+++ b/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
@@ -363,26 +363,35 @@
          [rich-text-editor/display-markdown body]])
 
       [typography/BoldGreyText (tr [:common :files])]
-      [file-view/file-table {:filtering? false
-                             :actions? true
-                             :no-link? true
-                             :attached-to [:meeting-agenda id]
-                             :columns #{:suffix :download}} files]
+      [file-view/file-table
+       {:filtering? false
+        :actions? true
+        :no-link? true
+        :attached-to [:meeting-agenda id]
+        :columns #{:suffix :download :delete}
+        :delete-action (fn [file]
+                         (e! (file-controller/map->DeleteAttachment
+                              {:file-id (:db/id file)
+                               :success-message (tr [:document :file-deleted-notification])
+                               :attached-to [:meeting-agenda id]})))}
+       files]
 
       [authorization-context/when-authorized :edit-meeting
-       [file-upload/FileUploadButton
+       [file-upload/FileUpload
         {:id (str "agenda-" id "-upload")
          :drag-container-id (str "agenda-" id)
          :drop-message (tr [:drag :drop-to-meeting-agenda])
-         :color :primary
-         :button-attributes {:icon [icons/file-cloud-upload]}
          :on-drop #(e! (file-controller/map->UploadFiles
                         {:files %
                          :project-id project-id
                          :attachment? true
                          :attach-to [:meeting-agenda id]
                          :on-success common-controller/->Refresh}))}
-        (tr [:task :upload-files])]]])])
+        [buttons/button-primary
+         {:start-icon (r/as-element [icons/file-cloud-upload])
+          :component :span}
+         (tr [:task :upload-files])]]]])])
+
 (defn meeting-details*
   [e! user {:meeting/keys [start end location agenda] :as meeting} rights]
   (let [edit? (get rights :edit-meeting)]

--- a/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
+++ b/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
@@ -36,7 +36,8 @@
             [teet.ui.authorization-context :as authorization-context]
             [teet.ui.file-upload :as file-upload]
             [teet.file.file-controller :as file-controller]
-            [teet.common.common-controller :as common-controller]))
+            [teet.common.common-controller :as common-controller]
+            [teet.file.file-view :as file-view]))
 
 
 (defn meeting-form
@@ -351,7 +352,8 @@
 
 
 (defn- meeting-agenda-content [e! {id :db/id
-                                   :meeting.agenda/keys [body files]}]
+                                   body :meeting.agenda/body
+                                   files :file/_attached-to}]
 
   [project-context/consume
    (fn [{project-id :db/id}]
@@ -359,6 +361,12 @@
       (when body
         [:div
          [rich-text-editor/display-markdown body]])
+
+      [typography/BoldGreyText (tr [:common :files])]
+      [file-view/file-table {:filtering? false
+                             :actions? false
+                             :columns #{:suffix}} files]
+
       [authorization-context/when-authorized :edit-meeting
        [file-upload/FileUploadButton
         {:id (str "agenda-" id "-upload")

--- a/app/frontend/src/cljs/teet/ui/buttons.cljs
+++ b/app/frontend/src/cljs/teet/ui/buttons.cljs
@@ -4,7 +4,6 @@
             [teet.ui.icons :as icons]
             [teet.ui.util :as util]
             [teet.localization :refer [tr]]
-            [teet.ui.icons :as icons]
             [teet.theme.theme-colors :as theme-colors]
             [reagent.core :as r]
             [teet.ui.panels :as panels]))

--- a/app/frontend/src/cljs/teet/ui/buttons.cljs
+++ b/app/frontend/src/cljs/teet/ui/buttons.cljs
@@ -1,6 +1,7 @@
 (ns teet.ui.buttons
   (:require [herb.core :refer [<class]]
-            [teet.ui.material-ui :refer [Button ButtonBase Link DialogActions DialogContentText]]
+            [teet.ui.material-ui :refer [Button ButtonBase Link DialogActions DialogContentText IconButton]]
+            [teet.ui.icons :as icons]
             [teet.ui.util :as util]
             [teet.localization :refer [tr]]
             [teet.ui.icons :as icons]
@@ -107,7 +108,7 @@
                              :type      :button}))
 
 (defn delete-button-with-confirm
-  [{:keys [action modal-title modal-text style small? icon-position close-on-action? id]
+  [{:keys [action modal-title modal-text style trashcan? small? icon-position close-on-action? id]
     :or {icon-position :end
          close-on-action? true}}
    button-content]
@@ -135,7 +136,12 @@
        (if modal-text
          modal-text
          (tr [:common :deletion-modal-text]))]]
-     (if small?
+     (cond
+       trashcan?
+       [IconButton {:on-click open}
+        [icons/action-delete]]
+
+       small?
        [button-text-warning (merge {:on-click open
                                     :id id
                                     :size :small}
@@ -143,6 +149,8 @@
                                      :end {:end-icon (r/as-element [icons/action-delete-outline])}
                                      :start {:start-icon (r/as-element [icons/action-delete-outline])}))
         button-content]
+
+       :else
        [button-warning {:on-click open
                         :style    style
                         :id id}


### PR DESCRIPTION
Add attachments to meeting agenda items.

Reviewers and organizer can upload new attachments, all participants can access them.