### PR TITLE
TEET-878 smaller UUID numbers

### DIFF
--- a/app/backend/src/clj/teet/activity/activity_commands.clj
+++ b/app/backend/src/clj/teet/activity/activity_commands.clj
@@ -12,7 +12,8 @@
             [teet.util.datomic :as du]
             [teet.permission.permission-db :as permission-db]
             [teet.util.collection :as cu]
-            [teet.user.user-model :as user-model]))
+            [teet.user.user-model :as user-model]
+            [teet.thk.thk-mapping :as thk-mapping]))
 
 (defn valid-activity-name?
   "Check if the activity name is valid for the lifecycle it's being added to"
@@ -119,7 +120,7 @@
         project-id (project-db/lifecycle-project-id db lifecycle-id)]
     (tx-ret [(merge
               {:db/id "new-activity"
-               :integration/id (java.util.UUID/randomUUID)
+               :integration/id (thk-mapping/unused-random-small-uuid db)
                :activity/status :activity.status/in-preparation}
               (-> activity
                   (select-keys [:activity/name
@@ -141,7 +142,7 @@
                             :task/type task-type
                             :task/send-to-thk? send-to-thk?}
                            (when send-to-thk?
-                             {:integration/id (java.util.UUID/randomUUID)})
+                             {:integration/id (thk-mapping/unused-random-small-uuid db)})
                            (meta-model/creation-meta user))))})
               (meta-model/creation-meta user))
              {:db/id lifecycle-id
@@ -189,7 +190,7 @@
                                 :task/type task-type
                                 :task/send-to-thk? send-to-thk?}
                                (when send-to-thk?
-                                 {:integration/id (java.util.UUID/randomUUID)})
+                                 {:integration/id (thk-mapping/unused-random-small-uuid db)})
                                (meta-model/creation-meta user))
                         [:db/add id :activity/tasks id-placeholder]])))))})
 

--- a/app/backend/src/clj/teet/thk/thk_import.clj
+++ b/app/backend/src/clj/teet/thk/thk_import.clj
@@ -127,7 +127,7 @@
                                        (when lc-teet-id
                                          (str "having TEET :integration/id " lc-teet-id)))
                            lc-integration-id (or lc-integration-id
-                                                 (let [new-uuid (java.util.UUID/randomUUID)]
+                                                 (let [new-uuid (thk-mapping/unused-random-small-uuid db)]
                                                    (log/info "Creating new UUID for THK lifecycle " lc-thk-id " => " new-uuid)
                                                    new-uuid))]]
                  (cu/without-nils
@@ -170,7 +170,7 @@
                                             (when act-integration-id
                                               (str "having TEET :integration/id " act-integration-id)))
                                 act-integration-id (or act-integration-id
-                                                       (let [new-uuid (java.util.UUID/randomUUID)]
+                                                       (let [new-uuid (thk-mapping/unused-random-small-uuid db)]
                                                          (log/info "Creating new UUID for THK activity " act-thk-id " => " new-uuid)
                                                          new-uuid))]]
                       (merge

--- a/app/backend/src/clj/teet/thk/thk_mapping.clj
+++ b/app/backend/src/clj/teet/thk/thk_mapping.clj
@@ -1,7 +1,8 @@
 (ns teet.thk.thk-mapping
   "Mapping of information between THK CSV and TEET attribute keywords"
   (:require [clojure.string :as str]
-            [clojure.java.io :as io])
+            [clojure.java.io :as io]
+            [datomic.client.api :as d])
   (:import (java.text SimpleDateFormat)))
 
 (defn- blank? [s]
@@ -23,6 +24,24 @@
     (let [lsb (.longValue n)
           msb (.longValue (.shiftRight n 64))]
       (java.util.UUID. msb lsb))))
+
+(defonce random (java.security.SecureRandom.))
+
+(defn random-small-uuid
+  "Create a UUID that only has 64bits number. This is because THK
+  teet id numbers are only int8 sized and cannot fit a full UUID"
+  []
+  (number->uuid (.nextLong random)))
+
+(defn- used-integration-id? [db id]
+  (boolean
+   (seq
+    (d/q '[:find ?e :where [?e :integration/id ?v] :in $ ?v] db id))))
+
+(defn unused-random-small-uuid [db]
+  (first
+   (drop-while (partial used-integration-id? db)
+               (repeatedly random-small-uuid))))
 
 (defn ->num [str]
   (when-not (blank? str)

--- a/app/frontend/src/cljs/teet/link/link_view.cljs
+++ b/app/frontend/src/cljs/teet/link/link_view.cljs
@@ -60,10 +60,11 @@
                                     :from from
                                     :in-progress-atom in-progress})
            links)
-     (tr [:link :search])
      (when-not @in-progress
        [select/select-search
         {:e! e!
+         :placeholder (tr [:link :search :placeholder])
+         :no-results (tr [:link :search :no-results])
          :query (fn [text]
                   {:args {:lang @localization/selected-language
                           :text text
@@ -71,6 +72,7 @@
                           :types #{:task}}
                    :query :link/search})
          :on-change add-link!
+
          :format-result (fn [{:task/keys [type assignee estimated-end-date]}]
                           [:div {:class (<class common-styles/flex-row-space-between)}
                            [:div (tr-enum type)]

--- a/app/frontend/src/cljs/teet/ui/select.cljs
+++ b/app/frontend/src/cljs/teet/ui/select.cljs
@@ -369,8 +369,10 @@
   [{:keys [e! value on-change label required error
            format-result
            show-label? after-results-action
-           query]
-    :or {show-label? true}}]
+           query placeholder no-results]
+    :or {show-label? true
+         placeholder (tr [:user :autocomplete :placeholder])
+         no-results (tr [:user :autocomplete :no-options])}}]
   (r/with-let [state (r/atom {:loading? false
                               :results nil
                               :open? false
@@ -384,7 +386,7 @@
                    :show-label? show-label?
                    :required required
                    :error error
-                   :placeholder (tr [:user :autocomplete :placeholder])
+                   :placeholder placeholder
                    :on-key-down on-key-down
                    :on-blur #(js/setTimeout
                               ;; Delay closing because we might be blurring
@@ -449,7 +451,8 @@
                                          (on-change result))}
                            (format-result result)])
                         results)
-                [:span.select-user-no-results {:style {:padding "0.5rem"}} (tr [:user :autocomplete :no-options])])
+                [:span.select-user-no-results {:style {:padding "0.5rem"}}
+                 no-results])
               (when-let [{:keys [title on-click]} after-results-action]
                 [:<>
                  [Divider]


### PR DESCRIPTION
Use only 64 bits in the UUID numbers as THK has column type int8.

Ids are created by secure random and checked against the current database that they are not in use.