### PR TITLE
TEET-722 Add audit? option to actions, audit log privilege granting commands

### DIFF
--- a/app/backend/src/clj/teet/activity/activity_commands.clj
+++ b/app/backend/src/clj/teet/activity/activity_commands.clj
@@ -114,7 +114,9 @@
          (not (activity-db/conflicting-activities? db activity lifecycle-id))
 
          ^{:error :invalid-tasks}
-         (valid-tasks? db (:activity/name activity) tasks)]}
+         (valid-tasks? db (:activity/name activity) tasks)]
+   ;; Audited as the command can grant privileges
+   :audit? true}
 
   (let [manager (:activity/manager activity)
         project-id (project-db/lifecycle-project-id db lifecycle-id)]

--- a/app/backend/src/clj/teet/admin/admin_commands.clj
+++ b/app/backend/src/clj/teet/admin/admin_commands.clj
@@ -74,6 +74,7 @@
    :pre [(:user/person-id user-data)
          (user-spec/estonian-person-id? (:user/person-id user-data))]
    :authorization {:admin/add-user {}}
+   :audit? true
    :transact (let [user-person-id (user-model/normalize-person-id (:user/person-id user-data))
                    user-info (user-db/user-info-by-person-id db user-person-id)
                    global-permission (:user/add-global-permission user-data)]

--- a/app/backend/src/clj/teet/log.clj
+++ b/app/backend/src/clj/teet/log.clj
@@ -88,6 +88,11 @@
          (and (keyword? audit-event)
               (some? (namespace audit-event)))
          (map? audit-event-args)]}
+  ;; This is for testing purposes, to ensure that audit gets called.
+  ;; Remove as part of TEET-785
+  (timbre/info {:audit/event audit-event
+                :audit/user-id user-id
+                :audit/event-args audit-event-args})
   (event "Audit"
          {:audit/event audit-event
           :audit/user-id user-id

--- a/app/backend/src/clj/teet/project/project_commands.clj
+++ b/app/backend/src/clj/teet/project/project_commands.clj
@@ -138,7 +138,8 @@
    :project-id project-id
    :pre [(:user/person-id user)
          (user-spec/estonian-person-id? (:user/person-id user))]
-   :authorization {:project/edit-permissions {:link :thk.project/owner}}}
+   :authorization {:project/edit-permissions {:link :thk.project/owner}}
+   :audit? true}
   (assert (authorization-check/role-can-be-granted? role) "Can't grant role")
   (let [user-person-id (-> user
                            :user/person-id


### PR DESCRIPTION
This PR adds the option to add audit logging to actions (that is, commands and queries) by adding `audit? true` to the action options. This results in the attempt to call the given action being logged into audit log.