### PR TITLE
TEET-844 reload config

### DIFF
--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -15,8 +15,7 @@
             [clojure.string :as str]
             [teet.integration.postgrest :as postgrest]
             [cheshire.core :as cheshire])
-  (:import (java.time LocalDate)
-           (java.time.format DateTimeFormatter)))
+  (:import (java.time.format DateTimeFormatter)))
 
 (defn prepare [form]
   (walk/prewalk

--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -138,8 +138,8 @@
   (.format (java.time.LocalDate/now) DateTimeFormatter/ISO_LOCAL_DATE))
 
 (defn backup* [_event]
-  (let [bucket (environment/ssm-param :s3 :backup-bucket)
-        env (environment/ssm-param :env)
+  (let [bucket (environment/config-value :backup :bucket-name)
+        env (environment/config-value :env)
         db (d/db (environment/datomic-connection))
         file-key (str env "-backup-"
                       (current-iso-date)

--- a/app/backend/src/clj/teet/environment.clj
+++ b/app/backend/src/clj/teet/environment.clj
@@ -5,7 +5,6 @@
             [teet.log :as log]
             [datomic.client.api :as d]
             [cognitect.aws.client.api :as aws]
-            [clojure.walk :as walk]
             [teet.util.collection :as cu])
   (:import (java.time ZoneId)
            (java.util.concurrent TimeUnit Executors)))

--- a/app/backend/src/clj/teet/environment.clj
+++ b/app/backend/src/clj/teet/environment.clj
@@ -102,7 +102,8 @@
           :client-id (->ssm [:auth :tara :clientid])
           :client-secret (->ssm [:auth :tara :secret])}
    :session-cookie-key (->ssm [:auth :session-key])
-   :auth {:basic-auth-password (->ssm [:api :basic-auth-password] nil)}
+   :auth {:basic-auth-password (->ssm [:api :basic-auth-password] nil)
+          :jwt-secret (->ssm [:api :jwt-secret])}
    :base-url (->ssm [:base-url])
    :api-url (->ssm [:api :url])
    :document-storage {:bucket-name (->ssm [:s3 :document-bucket])}

--- a/app/backend/src/clj/teet/environment.clj
+++ b/app/backend/src/clj/teet/environment.clj
@@ -4,8 +4,11 @@
             [clojure.java.io :as io]
             [teet.log :as log]
             [datomic.client.api :as d]
-            [cognitect.aws.client.api :as aws])
-  (:import (java.time ZoneId)))
+            [cognitect.aws.client.api :as aws]
+            [clojure.walk :as walk]
+            [teet.util.collection :as cu])
+  (:import (java.time ZoneId)
+           (java.util.concurrent TimeUnit Executors)))
 
 (def ^:private ssm-client (delay (aws/client {:api :ssm})))
 
@@ -32,38 +35,6 @@
                         {:param-path param-path :default-value default-value}
                         e))))))
 
-(defn- ssm-parameters [parameter-paths default-values]
-  (let [name->path (into {}
-                         (map (fn [path]
-                                [(str "/teet/" (str/join "/" (map name path)))
-                                 path]))
-                         parameter-paths)
-
-        ;; GetParameters supports at most 10 parameters in a single call
-        ;; so we partition keys and invoke the operation for each batch
-        responses (for [keys (partition-all 10 (keys name->path))]
-                    (aws/invoke @ssm-client
-                                {:op :GetParameters
-                                 :request {:Names (vec keys)}}))]
-    (reduce
-     merge
-     (for [response responses]
-       (merge
-        (into {}
-              (map (fn [{:keys [Name Value]}]
-                     [(name->path Name) Value]))
-              (:Parameters response))
-        (into {}
-              (map (fn [missing-parameter-name]
-                     (let [path (name->path missing-parameter-name)
-                           value (get default-values path)]
-                       (if (nil? value)
-                         (throw (ex-info "Missing parameter that has no default value"
-                                         {:parameter-name missing-parameter-name
-                                          :parameter-path path}))
-                         [path value]))))
-              (:InvalidParameters response)))))))
-
 (def init-config {:datomic {:db-name "teet"
                             :client {:server-type :ion}}
 
@@ -83,54 +54,104 @@
        (map keyword)
        set))
 
-(defn enabled-features-config []
-  (or (some-> [:enabled-features]
-              (ssm-param-default nil)
-              parse-enabled-features)
-      (do
-        (log/warn "SSM parameter enabled-features not found, treating all as disabled")
-        #{})))
-
-(defn tara-config []
-  (let [p (partial ssm-param :auth :tara)]
-    {:endpoint-url (p :endpoint)
-     :base-url (p :baseurl)
-     :client-id (p :clientid)
-     :client-secret (p :secret)}))
-
 (defn log-timezone-config! []
   (log/info "local timezone:" (ZoneId/systemDefault)))
 
+(defrecord SSMParameter [path default-value parser])
+
+(defn ->ssm
+  "Construct an SSMParameter instance"
+  ([path] (->ssm path ::no-default-value))
+  ([path default-value]
+   (->ssm path default-value identity))
+  ([path default-value parser]
+   (assert (vector? path) "Path must be a vector")
+   (assert (fn? parser) "Parser must be a function")
+   (->SSMParameter path default-value parser)))
+
+(defn- ssm-parameters
+  "Fetch a collection of SSM parameters in one go.
+  Parameters is a collection of SSMParameter instances.
+  Returns mapping from SSMParameter to the value.
+
+  If a parameter is missing and it doesn't have a default value,
+  an exception will be thrown."
+  [parameters]
+  (let [name->parameter (into {}
+                              (map (fn [{path :path :as param}]
+                                     [(str "/teet/" (str/join "/" (map name path)))
+                                      param]))
+                              parameters)
+
+        ;; GetParameters supports at most 10 parameters in a single call
+        ;; so we partition keys and invoke the operation for each batch
+        responses (for [keys (partition-all 10 (keys name->parameter))]
+                    (aws/invoke @ssm-client
+                                {:op :GetParameters
+                                 :request {:Names (vec keys)}}))]
+    (reduce
+     merge
+     (for [response responses]
+       (merge
+        (into {}
+              (map (fn [{:keys [Name Value]}]
+                     (let [{parser :parser :as param} (name->parameter Name)]
+                       [param (parser Value)])))
+              (:Parameters response))
+        (into {}
+              (map (fn [missing-parameter-name]
+                     (let [{:keys [path default-value]}
+                           (name->parameter missing-parameter-name)]
+                       (if (= default-value ::no-default-value)
+                         (throw (ex-info "Missing parameter that has no default value"
+                                         {:parameter-name missing-parameter-name
+                                          :parameter-path path}))
+                         [path default-value]))))
+              (:InvalidParameters response)))))))
+
+(defn- resolve-ssm-parameters
+  "Resolve multiple SSM parameters in a nested structure."
+  [form]
+  (cu/replace-deep
+   (ssm-parameters
+    (cu/collect (partial instance? SSMParameter) form))
+   form))
+
+(def teet-ssm-config
+  {:enabled-features (->ssm [:enabled-features] #{} parse-enabled-features)
+   :tara {:endpoint-url (->ssm [:auth :tara :endpoint])
+          :base-url (->ssm [:auth :tara :baseurl])
+          :client-id (->ssm [:auth :tara :clientid])
+          :client-secret (->ssm [:auth :tara :secret])}
+   :session-cookie-key (->ssm [:auth :session-key])
+   :auth {:basic-auth-password (->ssm [:api :basic-auth-password] nil)}
+   :base-url (->ssm [:base-url])
+   :api-url (->ssm [:api :url])
+   :document-storage {:bucket-name (->ssm [:s3 :document-bucket])}
+   :thk {:export-bucket-name (->ssm [:thk :teet-to-thk :bucket-name] nil)
+         :export-dir (->ssm [:thk :teet-to-thk :unprocesseddir] nil)}
+   :road-registry {:wfs-url (->ssm [:road-registry :wfs-url] nil)
+                   :wms-url (->ssm [:road-registry :wms-url] nil)}
+   :xroad {:query-url (->ssm [:xroad-query-url] nil)
+           :instance-id (->ssm [:xroad-instance-id] nil)
+           :kr-subsystem-id (->ssm [:xroad-kr-subsystem-id] nil)}
+   :eelis {:wms-url (->ssm [:eelis :wms-url] nil)}})
+
+(defn- load-ssm-config! [base-config]
+  (let [old-config @config
+        new-config (merge base-config
+                          (resolve-ssm-parameters teet-ssm-config))]
+    (when (not= old-config new-config)
+      (log/info "Configuration changed")
+      (reset! config new-config))))
+
 (defn init-ion-config! [ion-config]
   (log-timezone-config!)
-  (swap! config
-         (fn [base-config]
-           (let [config (merge base-config ion-config)
-                 config (assoc-in config [:auth :jwt-secret]
-                                  (ssm-param :api :jwt-secret))
-                 bap (ssm-param :api :basic-auth-password)
-                 tara (tara-config)
-                 ;;
-                 config (-> config
-                            (assoc :enabled-features (enabled-features-config))
-                            (assoc :tara tara)
-                            (assoc :session-cookie-key
-                                   (ssm-param :auth :session-key))
-                            (assoc-in [:auth :basic-auth-password] bap)
-                            (assoc :base-url (ssm-param :base-url))
-                            (assoc :api-url (ssm-param :api :url))
-                            (assoc-in [:document-storage :bucket-name] (ssm-param :s3 :document-bucket))
-                            (assoc-in [:thk :export-bucket-name] (ssm-param-default [:thk :teet-to-thk :bucket-name] nil))
-                            (assoc-in [:thk :export-dir] (ssm-param-default [:thk :teet-to-thk :unprocesseddir] nil))
-                            (assoc-in [:road-registry]
-                                      {:wfs-url (ssm-param-default [:road-registry :wfs-url] nil)
-                                       :wms-url (ssm-param-default [:road-registry :wms-url] nil)})
-                            (assoc-in [:xroad] {:query-url (ssm-param-default [:xroad-query-url] nil)
-                                                :instance-id (ssm-param-default [:xroad-instance-id] nil)
-                                                :kr-subsystem-id (ssm-param-default [:xroad-kr-subsystem-id] nil)})
-                            (assoc-in [:eelis]
-                                      {:wms-url (ssm-param-default [:eelis :wms-url] nil)}))]
-             config))))
+  (let [base-config (merge init-config ion-config)]
+    (.scheduleWithFixedDelay
+     (Executors/newScheduledThreadPool 1)
+     #(load-ssm-config! base-config)
+     0 1 TimeUnit/MINUTES)))
 
 (defn load-local-config!
   "Load local development configuration from outside repository"

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -303,7 +303,7 @@
                                       :cancel? false})
         email-response
         (integration-email/send-email!
-          {:from (environment/ssm-param :email :from)
+          {:from (environment/config-value :email :from)
            :to to
            :subject (email-subject-for-type meeting
                                             invitation-or-past-update?)
@@ -388,7 +388,7 @@
                                           :cancel? true})
             email-response (when (:meeting/invitations-sent-at meeting) ;; check that for this meeting invitations have been sent
                              (integration-email/send-email!
-                               {:from (environment/ssm-param :email :from)
+                               {:from (environment/config-value :email :from)
                                 :to to
                                 :subject (str "TEET: " (meeting-model/meeting-title meeting) " tühistatud" " / "
                                               "TEET: " (meeting-model/meeting-title meeting) " cancelled")

--- a/app/backend/src/clj/teet/notification/notification_sender.clj
+++ b/app/backend/src/clj/teet/notification/notification_sender.clj
@@ -58,7 +58,7 @@
         db (d/db conn)
         notifications (notification-db/notifications-to-send db)
         now (java.util.Date.)
-        from (environment/ssm-param :email :from)
+        from (environment/config-value :email :from)
         base-url (environment/config-value :base-url)]
 
     (if (empty? notifications)

--- a/app/backend/test/teet/environment_test.clj
+++ b/app/backend/test/teet/environment_test.clj
@@ -27,5 +27,5 @@
 
 (deftest parse-enabled-features
   (testing "parses a comma separated list of feature names into keyword set, trimming whitespace"
-    (is (= (environment/parse-enabled-features " foo , bar-bar,quux,,,")
+    (is (= (#'environment/parse-enabled-features " foo , bar-bar,quux,,,")
            #{:foo :bar-bar :quux}))))


### PR DESCRIPTION
Fetch all SSM configuration in batches and reload it once a minute.
Change all direct AWS API calls to use the centralized config instead.