### PR TITLE
TEET-905 use :integration/id for project geometries

### DIFF
--- a/app/backend/resources/schema.edn
+++ b/app/backend/resources/schema.edn
@@ -1454,4 +1454,7 @@
  {:db/ident :migration/remove-overlapping-global-rights-properly
   :txes [teet.migration.user-permissions/remove-overlapping-global-rights]}
 
+ {:db/ident :migration/thk-project-integration-id
+  :txes [teet.migration.thk-integration-id/migrate-projects]}
+
  ]

--- a/app/backend/src/clj/teet/activity/activity_commands.clj
+++ b/app/backend/src/clj/teet/activity/activity_commands.clj
@@ -13,7 +13,7 @@
             [teet.permission.permission-db :as permission-db]
             [teet.util.collection :as cu]
             [teet.user.user-model :as user-model]
-            [teet.thk.thk-mapping :as thk-mapping]))
+            [teet.integration.integration-id :as integration-id]))
 
 (defn valid-activity-name?
   "Check if the activity name is valid for the lifecycle it's being added to"
@@ -122,7 +122,7 @@
         project-id (project-db/lifecycle-project-id db lifecycle-id)]
     (tx-ret [(merge
               {:db/id "new-activity"
-               :integration/id (thk-mapping/unused-random-small-uuid db)
+               :integration/id (integration-id/unused-random-small-uuid db)
                :activity/status :activity.status/in-preparation}
               (-> activity
                   (select-keys [:activity/name
@@ -144,7 +144,7 @@
                             :task/type task-type
                             :task/send-to-thk? send-to-thk?}
                            (when send-to-thk?
-                             {:integration/id (thk-mapping/unused-random-small-uuid db)})
+                             {:integration/id (integration-id/unused-random-small-uuid db)})
                            (meta-model/creation-meta user))))})
               (meta-model/creation-meta user))
              {:db/id lifecycle-id
@@ -192,7 +192,7 @@
                                 :task/type task-type
                                 :task/send-to-thk? send-to-thk?}
                                (when send-to-thk?
-                                 {:integration/id (thk-mapping/unused-random-small-uuid db)})
+                                 {:integration/id (integration-id/unused-random-small-uuid db)})
                                (meta-model/creation-meta user))
                         [:db/add id :activity/tasks id-placeholder]])))))})
 

--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -11,7 +11,6 @@
             [teet.util.datomic :as du]
             [teet.log :as log]
             [clojure.string :as str]
-            [teet.integration.postgrest :as postgrest]
             [cheshire.core :as cheshire])
   (:import (java.time.format DateTimeFormatter)))
 
@@ -26,18 +25,6 @@
       (lazy-seq
        (cons item
              (read-seq rdr))))))
-
-(defn- replace-entity-ids!
-  "Replace entity ids in postgres entity table. List of ids
-  is comma separated list of old_id=new_id."
-  [{:keys [tempids] :as ctx}]
-  (log/info "Replace " (count tempids) " entity ids in PostgREST")
-  (postgrest/rpc ctx :replace_entity_ids
-                 {:idlist (str/join ","
-                                    (map (fn [[old-id new-id]]
-                                           (str old-id "=" new-id))
-                                         tempids))})
-  ctx)
 
 (defstep download-backup-file
   {:doc "Download backup file from S3 to temporary directory. Puts file path to context"
@@ -272,7 +259,6 @@
              check-backup-format
              prepare-database-for-restore
              restore-tx-file
-             replace-entity-ids!
              delete-backup-file)
       (catch Exception e
         (log/error e "ERROR IN RESTORE" (ex-data e)))))

--- a/app/backend/src/clj/teet/integration/integration_id.clj
+++ b/app/backend/src/clj/teet/integration/integration_id.clj
@@ -1,0 +1,42 @@
+(ns teet.integration.integration-id
+  "Utilities for working with :integration/id UUID numbers."
+  (:require [datomic.client.api :as d]))
+
+(defn uuid->number [uuid]
+  (let [bb (java.nio.ByteBuffer/wrap (byte-array 16))]
+    (.putLong bb (.getMostSignificantBits uuid))
+    (.putLong bb (.getLeastSignificantBits uuid))
+    (BigInteger. 1 (.array bb))))
+
+(defn number->uuid [n]
+  (if (= n (.longValue n))
+    ;; Fits into long type, this is old :db/id value
+    (java.util.UUID. 0 n)
+
+    ;; Otherwise new full UUID
+    (let [lsb (.longValue n)
+          msb (.longValue (.shiftRight n 64))]
+      (java.util.UUID. msb lsb))))
+
+(defonce random (java.security.SecureRandom.))
+
+
+(defn random-small-uuid
+  "Create a UUID that only has 64bits number. This is because some
+  systems (like THK) have id numbers that are only int8 sized and cannot
+  fit a full UUID."
+  []
+  (let [n (.nextLong random)]
+    (if (pos? n)
+      (number->uuid n)
+      (recur))))
+
+(defn- used-integration-id? [db id]
+  (boolean
+   (seq
+    (d/q '[:find ?e :where [?e :integration/id ?v] :in $ ?v] db id))))
+
+(defn unused-random-small-uuid [db]
+  (first
+   (drop-while (partial used-integration-id? db)
+               (repeatedly random-small-uuid))))

--- a/app/backend/src/clj/teet/migration/thk_integration_id.clj
+++ b/app/backend/src/clj/teet/migration/thk_integration_id.clj
@@ -1,7 +1,8 @@
 (ns teet.migration.thk-integration-id
   (:require [datomic.client.api :as d]
             [clojure.set :as set]
-            [teet.thk.thk-mapping :as thk-mapping]))
+            [teet.thk.thk-mapping :as thk-mapping]
+            [teet.integration.integration-id :as integration-id]))
 
 (defn- entities-with-attr [db attr]
   (into #{}
@@ -21,7 +22,7 @@
      {:tx-data (vec
                 (for [e entities]
                   {:db/id e
-                   :integration/id (thk-mapping/number->uuid e)}))})))
+                   :integration/id (integration-id/number->uuid e)}))})))
 
 (defn check-uuids [db]
   (every?
@@ -29,7 +30,7 @@
            integration-id :integration/id}
           (d/pull db [:db/id :integration/id] %)]
       (println "Check :db/id = " db-id ", :integration/id = " integration-id)
-      (= db-id (thk-mapping/uuid->number integration-id)))
+      (= db-id (integration-id/uuid->number integration-id)))
    (entities-with-attr db :thk.project/id)))
 
 (defn migrate-projects
@@ -42,4 +43,4 @@
      {:tx-data (vec
                 (for [p projects]
                   {:db/id p
-                   :integration/id (thk-mapping/number->uuid p)}))})))
+                   :integration/id (integration-id/number->uuid p)}))})))

--- a/app/backend/src/clj/teet/migration/thk_integration_id.clj
+++ b/app/backend/src/clj/teet/migration/thk_integration_id.clj
@@ -30,4 +30,16 @@
           (d/pull db [:db/id :integration/id] %)]
       (println "Check :db/id = " db-id ", :integration/id = " integration-id)
       (= db-id (thk-mapping/uuid->number integration-id)))
-   (entities-with-attr db :integration/id)))
+   (entities-with-attr db :thk.project/id)))
+
+(defn migrate-projects
+  "Migrate :integration/id for THK projects as well"
+  [conn]
+  (let [db (d/db conn)
+        projects (entities-with-attr db :thk.project/id)]
+    (d/transact
+     conn
+     {:tx-data (vec
+                (for [p projects]
+                  {:db/id p
+                   :integration/id (thk-mapping/number->uuid p)}))})))

--- a/app/backend/src/clj/teet/project/project_commands.clj
+++ b/app/backend/src/clj/teet/project/project_commands.clj
@@ -50,11 +50,12 @@
        (environment/config-map {:api-url [:api-url]
                                 :api-secret [:auth :jwt-secret]
                                 :wfs-url [:road-registry :wfs-url]})
-        [(d/pull db '[:db/id :thk.project/project-name :thk.project/name
-                      :thk.project/road-nr :thk.project/carriageway
-                      :thk.project/start-m :thk.project/end-m
-                      :thk.project/custom-start-m :thk.project/custom-end-m]
-                 [:thk.project/id id])]))
+       [(d/pull db '[:db/id :integration/id
+                     :thk.project/project-name :thk.project/name
+                     :thk.project/road-nr :thk.project/carriageway
+                     :thk.project/start-m :thk.project/end-m
+                     :thk.project/custom-start-m :thk.project/custom-end-m]
+                [:thk.project/id id])]))
     :ok))
 
 (defcommand :thk.project/revoke-permission

--- a/app/backend/src/clj/teet/project/project_db.clj
+++ b/app/backend/src/clj/teet/project/project_db.clj
@@ -216,7 +216,9 @@
   "Check if TEET has a project with the given THK project id"
   [db thk-project-id]
   (boolean
-   (ffirst (d/q '[:find ?e :where [?e :thk.project/id ?project-id] :in $ ?project-id]
+   (ffirst (d/q '[:find ?e
+                  :where [?e :thk.project/id ?project-id]
+                  :in $ ?project-id]
                 db thk-project-id))))
 
 (defn project-has-owner?

--- a/app/backend/src/clj/teet/project/project_geometry.clj
+++ b/app/backend/src/clj/teet/project/project_geometry.clj
@@ -6,7 +6,8 @@
             [clojure.string :as str]
             [cheshire.core :as cheshire]
             [teet.road.road-query :as road-query]
-            [teet.util.geo :as geo]))
+            [teet.util.geo :as geo]
+            [teet.integration.integration-id :as integration-id]))
 
 (defn- valid-api-info? [{:keys [api-url api-secret]}]
   (and (not (str/blank? api-url))
@@ -18,12 +19,13 @@
   [{:keys [api-url api-secret wfs-url] :as api} projects]
   {:pre [(valid-api-info? api)]}
   (let [road-part-cache (atom {})
-        request-body (for [{id :db/id
+        request-body (for [{id :integration/id
                             :thk.project/keys [project-name name road-nr carriageway
                                                start-m end-m
                                                custom-start-m custom-end-m]}
                            projects
-                           :when (and (integer? (or custom-start-m start-m))
+                           :when (and id
+                                      (integer? (or custom-start-m start-m))
                                       (integer? (or custom-end-m end-m))
                                       (integer? road-nr)
                                       (integer? carriageway))
@@ -32,7 +34,7 @@
                                                                           road-nr carriageway
                                                                           (or custom-start-m start-m)
                                                                           (or custom-end-m end-m))]]
-                       {:id (str id)
+                       {:id (str (integration-id/uuid->number id))
                         :type "project"
                         :tooltip (or project-name name)
                         :geometry_wkt (geo/line-string-to-wkt geometry)})]

--- a/app/backend/src/clj/teet/thk/thk_export.clj
+++ b/app/backend/src/clj/teet/thk/thk_export.clj
@@ -3,7 +3,8 @@
   (:require [datomic.client.api :as d]
             [teet.activity.activity-model :as activity-model]
             [teet.thk.thk-mapping :as thk-mapping]
-            [teet.meta.meta-query :as meta-query]))
+            [teet.meta.meta-query :as meta-query]
+            [teet.integration.integration-id :as integration-id]))
 
 (defn- all-projects [db]
   (d/q '[:find (pull ?e [*
@@ -46,7 +47,7 @@
                               #(some? (:thk.activity/id %))))
 
 (defn export-thk-projects [connection]
-  
+
   (let [db (d/db connection)
         projects (->> db
                       all-projects
@@ -83,9 +84,9 @@
 
                  ;; TEET id for phase and activity
                  "phase_teetid"
-                 (str (thk-mapping/uuid->number (:integration/id lifecycle)))
+                 (str (integration-id/uuid->number (:integration/id lifecycle)))
                  "activity_teetid"
-                 (str (thk-mapping/uuid->number (:integration/id activity)))
+                 (str (integration-id/uuid->number (:integration/id activity)))
 
                  ;; Regular columns
                  (let [{task-mapping :task :as mapping}

--- a/app/backend/src/clj/teet/thk/thk_import.clj
+++ b/app/backend/src/clj/teet/thk/thk_import.clj
@@ -13,7 +13,8 @@
             [teet.util.collection :as cu]
             [teet.thk.thk-mapping :as thk-mapping]
             [teet.log :as log]
-            [teet.project.project-db :as project-db])
+            [teet.project.project-db :as project-db]
+            [teet.integration.integration-id :as integration-id])
   (:import (org.apache.commons.io.input BOMInputStream)))
 
 (def excluded-project-types #{"TUGI" "TEEMU"})
@@ -126,7 +127,7 @@
                                        (when lc-teet-id
                                          (str "having TEET :integration/id " lc-teet-id)))
                            lc-integration-id (or lc-integration-id
-                                                 (let [new-uuid (thk-mapping/unused-random-small-uuid db)]
+                                                 (let [new-uuid (integration-id/unused-random-small-uuid db)]
                                                    (log/info "Creating new UUID for THK lifecycle " lc-thk-id " => " new-uuid)
                                                    new-uuid))]]
                  (cu/without-nils
@@ -169,7 +170,7 @@
                                             (when act-integration-id
                                               (str "having TEET :integration/id " act-integration-id)))
                                 act-integration-id (or act-integration-id
-                                                       (let [new-uuid (thk-mapping/unused-random-small-uuid db)]
+                                                       (let [new-uuid (integration-id/unused-random-small-uuid db)]
                                                          (log/info "Creating new UUID for THK activity " act-thk-id " => " new-uuid)
                                                          new-uuid))]]
                       (merge

--- a/app/backend/src/clj/teet/thk/thk_import.clj
+++ b/app/backend/src/clj/teet/thk/thk_import.clj
@@ -13,8 +13,7 @@
             [teet.util.collection :as cu]
             [teet.thk.thk-mapping :as thk-mapping]
             [teet.log :as log]
-            [teet.project.project-db :as project-db]
-            [teet.util.datomic :as du])
+            [teet.project.project-db :as project-db])
   (:import (org.apache.commons.io.input BOMInputStream)))
 
 (def excluded-project-types #{"TUGI" "TEEMU"})

--- a/app/backend/src/clj/teet/thk/thk_integration_ion.clj
+++ b/app/backend/src/clj/teet/thk/thk_integration_ion.clj
@@ -94,7 +94,7 @@
 
 (defn- update-entity-info [{db :db :as ctx}]
   (let [projects (map first
-                      (d/q '[:find (pull ?e [:db/id
+                      (d/q '[:find (pull ?e [:db/id :integration/id
                                              :thk.project/project-name :thk.project/name
                                              :thk.project/road-nr
                                              :thk.project/carriageway

--- a/app/backend/src/clj/teet/thk/thk_mapping.clj
+++ b/app/backend/src/clj/teet/thk/thk_mapping.clj
@@ -2,50 +2,13 @@
   "Mapping of information between THK CSV and TEET attribute keywords"
   (:require [clojure.string :as str]
             [clojure.java.io :as io]
-            [datomic.client.api :as d])
+            [teet.integration.integration-id :as integration-id])
   (:import (java.text SimpleDateFormat)))
 
 (defn- blank? [s]
   (or (not s)
       (str/blank? s)))
 
-(defn uuid->number [uuid]
-  (let [bb (java.nio.ByteBuffer/wrap (byte-array 16))]
-    (.putLong bb (.getMostSignificantBits uuid))
-    (.putLong bb (.getLeastSignificantBits uuid))
-    (BigInteger. 1 (.array bb))))
-
-(defn number->uuid [n]
-  (if (= n (.longValue n))
-    ;; Fits into long type, this is old :db/id value
-    (java.util.UUID. 0 n)
-
-    ;; Otherwise new full UUID
-    (let [lsb (.longValue n)
-          msb (.longValue (.shiftRight n 64))]
-      (java.util.UUID. msb lsb))))
-
-(defonce random (java.security.SecureRandom.))
-
-
-(defn random-small-uuid
-  "Create a UUID that only has 64bits number. This is because THK
-  teet id numbers are only int8 sized and cannot fit a full UUID"
-  []
-  (let [n (.nextLong random)]
-    (if (pos? n)
-      (number->uuid n)
-      (recur))))
-
-(defn- used-integration-id? [db id]
-  (boolean
-   (seq
-    (d/q '[:find ?e :where [?e :integration/id ?v] :in $ ?v] db id))))
-
-(defn unused-random-small-uuid [db]
-  (first
-   (drop-while (partial used-integration-id? db)
-               (repeatedly random-small-uuid))))
 
 (defn ->num [str]
   (when-not (blank? str)
@@ -57,7 +20,7 @@
 
 (defn ->numeric-uuid [str]
   (when-not (blank? str)
-    (-> str BigInteger. number->uuid)))
+    (-> str BigInteger. integration-id/number->uuid)))
 
 (defn- ->date [date-str]
   (when-not (blank? date-str)
@@ -251,7 +214,7 @@
    "phase_id" {:attribute :thk.lifecycle/id}
    "phase_teetid" {:attribute :lifecycle-db-id
                    :parse ->numeric-uuid
-                   :format #(str (uuid->number %))}
+                   :format #(str (integration-id/uuid->number %))}
    "phase_typefk" {:attribute :phase/typefk}
    "phase_shortname" {:attribute :thk.lifecycle/type
                       :parse phase-name->lifecycle-type
@@ -275,7 +238,7 @@
    "activity_taskid" {:attribute :activity/task-id
                       :parse ->numeric-uuid
                       :task {:attribute :integration/id
-                             :format #(str (uuid->number %))}}
+                             :format #(str (integration-id/uuid->number %))}}
    "activity_taskdescr" {:attribute :activity/task-description
                          :task {:attribute :task/type
                                 :format tr-enum}}

--- a/app/backend/test/teet/thk/thk_import_test.clj
+++ b/app/backend/test/teet/thk/thk_import_test.clj
@@ -12,7 +12,8 @@
             [teet.thk.thk-mapping :as thk-mapping]
             [clojure.java.io :as io]
             [teet.meta.meta-query :as meta-query]
-            [teet.meta.meta-model :as meta-model]))
+            [teet.meta.meta-model :as meta-model]
+            [teet.integration.integration-id :as integration-id]))
 
 (use-fixtures :each
   tu/with-global-data
@@ -157,9 +158,9 @@
           "task description is the estonian translation of task type")
       (is (str/blank? (get task-row "activity_id")) "task has no activity_id yet")
       (is (= (get task-row "activity_taskid")
-             (str (thk-mapping/uuid->number (tu/get-data :task-uuid)))))
+             (str (integration-id/uuid->number (tu/get-data :task-uuid)))))
       (is (= (get task-row "activity_teetid")
-             (str (thk-mapping/uuid->number (tu/get-data :act-uuid)))))))
+             (str (integration-id/uuid->number (tu/get-data :act-uuid)))))))
 
   (testing "Changing task and exporting again keeps same ids"
     (tu/local-command tu/mock-user-boss
@@ -172,9 +173,9 @@
                                            (export-csv))]
       (is (= 1 (count task-rows)) "still exactly one task row")
       (is (= (get task-row "activity_taskid")
-             (str (thk-mapping/uuid->number (tu/get-data :task-uuid)))))
+             (str (integration-id/uuid->number (tu/get-data :task-uuid)))))
       (is (= (get task-row "activity_teetid")
-             (str (thk-mapping/uuid->number (tu/get-data :act-uuid)))))))
+             (str (integration-id/uuid->number (tu/get-data :act-uuid)))))))
 
   (testing "Changing activity and exporting again keeps the same ids"
     (tu/local-command
@@ -187,9 +188,9 @@
                                            (export-csv))]
       (is (= 1 (count task-rows)) "still exactly one task row")
       (is (= (get task-row "activity_taskid")
-             (str (thk-mapping/uuid->number (tu/get-data :task-uuid)))))
+             (str (integration-id/uuid->number (tu/get-data :task-uuid)))))
       (is (= (get task-row "activity_teetid")
-             (str (thk-mapping/uuid->number (tu/get-data :act-uuid))))))))
+             (str (integration-id/uuid->number (tu/get-data :act-uuid))))))))
 
 (defn set-csv-column [csv row-test-column row-test-value set-col set-val]
   (let [test-col-idx (cu/find-idx #(= row-test-column %) thk-mapping/csv-column-names)
@@ -244,7 +245,7 @@
     (let [csv (tu/get-data :export-csv)
           act-teet-id (tu/get-data :act-uuid)
           csv-with-id (set-csv-column csv
-                                      "activity_teetid" (str (thk-mapping/uuid->number act-teet-id))
+                                      "activity_teetid" (str (integration-id/uuid->number act-teet-id))
                                       "activity_id" "99999")
           csv-data (->csv-data csv-with-id)
           lc->act->task-before (lc->act->task)]
@@ -275,7 +276,7 @@
           (set-csv-column
            (tu/get-data :export-csv)
            ;; when taskid is our created task
-           "activity_taskid" (str (thk-mapping/uuid->number (tu/get-data :task-uuid)))
+           "activity_taskid" (str (integration-id/uuid->number (tu/get-data :task-uuid)))
            ;; mock THK generated activity id
            "activity_id" "99887")
           hierarchy-before (lc->act->task)]

--- a/app/frontend/src/cljs/teet/map/map_layers.cljs
+++ b/app/frontend/src/cljs/teet/map/map_layers.cljs
@@ -117,7 +117,7 @@
         entity-query-options
         (if (vector? projects)
           ;; Have fetched projects, show only them
-          {"ids" (str "{" (str/join "," (map :db/id projects)) "}")}
+          {"ids" (str "{" (str/join "," (map :integration/id projects)) "}")}
           ;; Show all projects
           {"type" "project"})]
     {:projects

--- a/app/frontend/src/cljs/teet/project/project_controller.cljs
+++ b/app/frontend/src/cljs/teet/project/project_controller.cljs
@@ -630,8 +630,8 @@
   (process-event [{id :project-id} app]
     (t/fx app
           {:tuck.effect/type :query
-           :query            :thk.project/db-id->thk-id
-           :args             {:db/id (common-controller/->long id)}
+           :query            :thk.project/integration-id->thk-id
+           :args             {:integration/id (common-controller/->long id)}
            :result-event     ->NavigateToProject}))
 
   NavigateToProject

--- a/db/src/main/resources/db/migration/R__04_entity.sql
+++ b/db/src/main/resources/db/migration/R__04_entity.sql
@@ -154,33 +154,3 @@ SELECT ST_AsGML(ST_FlipCoordinates(ST_Collect(x.geometry)))
 $$ LANGUAGE SQL SECURITY DEFINER;
 
 GRANT EXECUTE ON FUNCTION teet.gml_entity_search_area(BIGINT,INTEGER) TO teet_backend;
-
-
-CREATE OR REPLACE FUNCTION teet.replace_entity_ids(idlist TEXT)
-RETURNS BOOLEAN
-AS $$
-DECLARE
-BEGIN
-  CREATE TEMPORARY TABLE new_ids (old_id BIGINT, new_id BIGINT);
-  INSERT INTO new_ids
-    SELECT y.ids[1]::bigint AS old_id, y.ids[2]::bigint AS new_id
-      FROM (SELECT regexp_split_to_array(x.row, '=') AS ids
-              FROM (SELECT regexp_split_to_table(idlist, ',') AS row) x) y;
-
-  -- Make new ids negative to prevent clashes with existing rows
-  UPDATE teet.entity
-     SET id = (SELECT -new_id FROM new_ids WHERE old_id=id)
-   WHERE EXISTS (SELECT new_id FROM new_ids WHERE old_id=id);
-
-  -- Flip all negative ids
-  UPDATE teet.entity
-     SET id = -id
-   WHERE id < 0;
-
-  DROP TABLE new_ids;
-
-  RETURN true;
-END;
-$$ LANGUAGE PLPGSQL SECURITY DEFINER;
-
-GRANT EXECUTE ON FUNCTION teet.replace_entity_ids(TEXT) TO teet_backend;

--- a/db/src/main/resources/db/migration/V17__remove_unused_rpc.sql
+++ b/db/src/main/resources/db/migration/V17__remove_unused_rpc.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION teet.replace_entity_ids(TEXT);


### PR DESCRIPTION
Create :integration/id for THK projects that can be used as stable id that doesn't need special handling when doing backup/restore.