### PR TITLE
TEET-967 0 size files in production

### DIFF
--- a/app/backend/test/teet/file/file_model_test.clj
+++ b/app/backend/test/teet/file/file_model_test.clj
@@ -1,0 +1,9 @@
+(ns teet.file.file-model-test
+  (:require [clojure.test :refer [deftest is]]
+            [teet.file.file-model :as file-model]))
+
+(deftest validate-file
+  (is (= (:error (file-model/validate-file {:file/size -3}))
+         :file-empty))
+  (is (= (:error (file-model/validate-file {:file/size 0}))
+         :file-empty)))

--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -538,8 +538,8 @@
   :file-new-part-text "TEET is designed to make you life easier",
   :invalid-sequence-number "Invalid sequence number",
   :already-uploaded "This file has already been uploaded",
-  :file-will-be-added-to-part
-  "This file will be added to {part} part"},
+  :file-will-be-added-to-part "This file will be added to {part} part",
+  :empty-file "Can't upload empty files"},
  :land
  {:show-owner-info "Show owner information",
   :no-active-mortgages

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -534,7 +534,8 @@
   :file-new-part-text "TEET püüab Sinu elu lihtsamaks teha",
   :invalid-sequence-number "Järjekorranumber ei ole korrektne",
   :already-uploaded "See fail on juba üles laaditud",
-  :file-will-be-added-to-part "See fail lisatakse {part} osasse"},
+  :file-will-be-added-to-part "See fail lisatakse {part} osasse",
+  :empty-file "Ei saa laadida tühje faile"},
  :land
  {:show-owner-info "Vaatan omanike andmeid",
   :no-active-mortgages "Aktiivsed hüpoteegid puuduvad",
@@ -645,7 +646,8 @@
   :add-non-teet-participant "Lisan TEET-u välise osaleja",
   :remove-participant-confirm-button "Eemaldan",
   :search-decisions "Otsin otsuseid",
-  :move-to-participants-modal-title nil,
+  :move-to-participants-modal-title
+  "Kas lisan kasutaja osalejate nimekirja?",
   :not-enough-participants
   "Teavituste saatmiseks on vaja lisada veel vähemalt üks osaleja.",
   :absentees-title "Puudujad",
@@ -653,13 +655,14 @@
   :add-decision-button "Lisan otsuse",
   :participant-removed "Osaleja eemaldatud",
   :approve-meeting-modal-title "Kinnitan otsused?",
-  :confirm-move nil,
+  :confirm-move "Liigutan kasutajat",
   :edit-meeting-modal-title "Muuda koosolekut",
   :activity-meetings-title "Koosolekud - {activity-name}",
-  :move-to-participants-modal-body nil,
+  :move-to-participants-modal-body
+  "Oled sa kindel, et soovid liigutada {participant} osalejate nimekirja? Kõik olemasolevad kinnitused tühistatakse.",
   :new-meeting-modal-title "Uus koosolek",
   :participants-title "Osalejad",
-  :moved-to-participants-successfully nil,
+  :moved-to-participants-successfully "Lisatud osalejate nimekirja",
   :reject-meeting-modal-title "Lükkan otsused tagasi?",
   :meetings-title "Koosolekud",
   :approve-meeting-button "Kinnitan otsused",
@@ -667,10 +670,12 @@
   :send-notification-to-participants "{count} osalejat",
   :add-agenda-button "Lisan päevakavapunkti",
   :no-absentees "Puudujaid pole",
-  :move-to-absentees-modal-title nil,
+  :move-to-absentees-modal-title
+  "Kas lisan kasutaja puudujate nimekirja?",
   :approvals "Kinnitused",
   :new-decision-modal-title "Uue otsuse lisamine",
-  :move-to-absentees-modal-body nil,
+  :move-to-absentees-modal-body
+  "Oled sa kindel, et soovid liigutada {participant} puudujate nimekirja? Kõik olemasolevad kinnitused tühistatakse.",
   :no-decisions-found "Ühtegi otsust ei leitud",
   :reviews-invalidated-warning-text
   "Muutes koosoleku sisu tühistatakse kõik juba antud kinnitused.",
@@ -682,7 +687,7 @@
   :project-meetings-title "Projekti koosolekud",
   :notifications-title "Teavitused",
   :duplicate-meeting-modal-title "Koosoleku koopia",
-  :moved-to-absentees-successfully nil,
+  :moved-to-absentees-successfully "Lisatud puudujate nimekirja",
   :edit-agenda-modal-title "Päevakavapunkti muutmine",
   :email-title "TEET: koosolek uuendatud: {meeting-title}",
   :new-agenda-modal-title "Uus päevakavapunkt",

--- a/app/common/src/cljc/teet/file/file_model.cljc
+++ b/app/common/src/cljc/teet/file/file_model.cljc
@@ -33,6 +33,9 @@
     (> size upload-max-file-size)
     {:error :file-too-large :max-allowed-size upload-max-file-size}
 
+    (<= size 0)
+    {:error :file-empty}
+
     (not (valid-suffix? name))
     {:error :file-type-not-allowed :allowed-suffixes (upload-allowed-file-suffixes)}
 

--- a/app/frontend/src/cljs/teet/ui/file_upload.cljs
+++ b/app/frontend/src/cljs/teet/ui/file_upload.cljs
@@ -153,6 +153,9 @@
         {:title (tr [:file-upload :invalid-sequence-number])
          :description ""}
 
+        :file-empty
+        {:title (tr [:file-upload :empty-file])
+         :description ""}
         ;; All validations ok
         :else nil))))
 


### PR DESCRIPTION
This PR is a part of a more investigative ticket TEET-967.

It adds validation preventing the upload of 0 size files in the frontend.
![Screenshot 2020-11-19 at 8 59 47](https://user-images.githubusercontent.com/3049382/99633364-704bea00-2a47-11eb-942a-909a426f4d71.png)
