### PR TITLE
TEET-1069 async processing of THK lambdas

### DIFF
--- a/app/backend/src/clj/teet/thk/thk_integration_ion.clj
+++ b/app/backend/src/clj/teet/thk/thk_integration_ion.clj
@@ -116,8 +116,7 @@
   (write-error-to-log ctx)
   nil)
 
-(defn process-thk-file
-  [event]
+(defn- process-thk-file* [event]
   (try
     (let [result (ctx-> {:event event
                          :connection (environment/datomic-connection)
@@ -131,11 +130,16 @@
                         update-entity-info
                         move-file-to-processed)]
       (log/event :thk-file-processed
-                 {:input result})
-      "{\"success\": true}")
+                 {:input result}))
     (catch Exception e
       (log/error (.getCause e) "Exception in THK import")
       (on-import-error (ex-data e)))))
+
+(defn process-thk-file
+  [event]
+  (future
+    (process-thk-file* event))
+  "{\"success\": true}")
 
 (defn import-thk-local-file
   [filepath]
@@ -161,8 +165,7 @@
 (defn export-projects [{conn :connection :as ctx}]
   (assoc ctx :csv (thk-export/export-thk-projects conn)))
 
-(defn export-projects-to-thk
-  [_event] ; ignore event (cron lambda trigger with no payload)
+(defn- export-projects-to-thk* []
   (try
     (ctx-> {:connection (environment/datomic-connection)
             :s3 {:bucket-name (environment/config-value :thk :export-bucket-name)
@@ -173,9 +176,14 @@
            export-projects
            csv->file
            write-file-to-s3)
-    "{\"success\": true}"
     (catch Exception e
       (log/error "Error exporting projects CSV to S3: " (pr-str (ex-data e))))))
+
+(defn export-projects-to-thk
+  [_event] ; ignore event (cron lambda trigger with no payload)
+  (future
+    (export-projects-to-thk*))
+  "{\"success\": true}")
 
 (defn export-projects-to-local-file [filepath]
   (let [dump (fn [{file :file}]


### PR DESCRIPTION
Changed lambda processing to be processed in the background (like backup/restore).
The lambda doesn't have to wait for response, as it isn't used.

No tests, as we don't have lambda trigger tests. 