### PR TITLE
TEET-1071 Fix caret jumping when editing existing mentions input

### DIFF
--- a/app/frontend/package-lock.json
+++ b/app/frontend/package-lock.json
@@ -3254,15 +3254,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-mentions": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/react-mentions/-/react-mentions-3.3.1.tgz",
-      "integrity": "sha512-/UOZXTgK2rvuyjj8T0wVb4AsAjcKahwG6PtweSdbZAWbwmkaGkm49Yu725D6Xyw73h4qZhvzIeIY0K8ichfAHg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/react-mentions/-/react-mentions-4.0.2.tgz",
+      "integrity": "sha512-NlWzoAHWeeciewwUqH5jF0PT1wqVKCeHUwy5BvcMspDR3M22jPtqQLsTBJTcLuu+c7dzy/f3snaa0S+UJnyJiA==",
       "requires": {
         "@babel/runtime": "7.4.5",
         "invariant": "^2.2.4",
-        "lodash": "^4.5.1",
         "prop-types": "^15.5.8",
-        "substyle": "^6.3.1"
+        "substyle": "^9.1.0"
       },
       "dependencies": {
         "@babel/runtime": {
@@ -3865,14 +3864,12 @@
       }
     },
     "substyle": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/substyle/-/substyle-6.3.1.tgz",
-      "integrity": "sha512-S25YRgVQB25cLXgGAJ7AXTYewkIB/9Fa1Y7jxkN48U4N6rbK9YhVEiF7vtPGLlJl8ebSOJ3N4t8cd6jL8MH7Uw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/substyle/-/substyle-9.3.0.tgz",
+      "integrity": "sha512-OK6A6EpqOfRvlwOnrgwFKIi8UDJwCQ2UB5cIJGMEFvl3zUUA83XDbRUJizECj66CdeZ9pGjkmwRxyc/9wBGQMA==",
       "requires": {
-        "hoist-non-react-statics": "^3.1.0",
-        "invariant": "^2.2.0",
-        "prop-types": "^15.5.8",
-        "warning": "^2.1.0"
+        "@babel/runtime": "^7.3.4",
+        "invariant": "^2.2.4"
       }
     },
     "supports-color": {
@@ -4195,14 +4192,6 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
       "dev": true
-    },
-    "warning": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-2.1.0.tgz",
-      "integrity": "sha1-ISINnGOvx3qMkhEeARr3Bc4MaQE=",
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
     },
     "watchpack": {
       "version": "1.7.2",

--- a/app/frontend/package.json
+++ b/app/frontend/package.json
@@ -17,6 +17,6 @@
     "proj4": "^2.5.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-mentions": "^3.3.1"
+    "react-mentions": "^4.0.2"
   }
 }

--- a/app/frontend/src/cljs/teet/map/openlayers/kuvataso.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers/kuvataso.cljs
@@ -6,7 +6,7 @@
             #_[teet.asiakas.kommunikaatio :refer [karttakuva-url]]
             [teet.map.openlayers.edistymispalkki :as palkki]
             [teet.map.openlayers.layer :refer [Layer]]
-            [cljs.core.async :as async]
+            [cljs.core.async :as async :refer [<!]]
             [clojure.string :as str])
   (:require-macros [cljs.core.async.macros :refer [go]]))
 

--- a/app/frontend/src/cljs/teet/map/openlayers/mvt.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers/mvt.cljs
@@ -5,7 +5,7 @@
               [ol.format.MVT]
               [ol.extent :as ol-extent]
               [teet.map.openlayers.layer :refer [Layer]]
-              [cljs.core.async :as async]
+              [cljs.core.async :as async :refer [<!]]
               [clojure.string :as str]
               [ol.style.Style]
               [ol.style.Text]

--- a/app/frontend/src/cljs/teet/ui/component_demo.cljs
+++ b/app/frontend/src/cljs/teet/ui/component_demo.cljs
@@ -1,7 +1,7 @@
 (ns teet.ui.component-demo
   (:require [clojure.string :as str]
             [teet.ui.material-ui :refer [Button Fab Divider Checkbox]]
-            [teet.ui.text-field :refer [TextField]]
+            [teet.ui.text-field :refer [TextField] :as text-field]
             [teet.ui.file-upload :as file-upload]
             [teet.ui.icons :as icons]
             [teet.ui.skeleton :as skeleton]
@@ -15,7 +15,6 @@
             [teet.log :as log]
             [reagent.core :as r]
             [teet.ui.rich-text-editor :as rich-text-editor]
-            [teet.ui.text-field :as text-field]
             [teet.ui.mentions :as mentions]))
 
 (defrecord TestFileUpload [files])
@@ -54,8 +53,7 @@
                  (if (.-ok resp)
                    (log/info "Upload ok" (.-status resp))
                    (log/warn "Upload failed: " (.-status resp) (.-statusText resp))))))
-    app)
-  )
+    app))
 
 (defn input-fields
   []
@@ -185,14 +183,16 @@
    [Checkbox {:color :secondary}]
    [Checkbox {:color :primary :disabled true}]])
 
-(defn- file-upload-demo []
-  [:div {:style {:display "flex"
+(defn- file-upload-demo [e!]
+  [:div {:id "file-upload-drag-container"
+         :style {:display "flex"
                  :justify-content "space-evenly"
                  :margin-bottom "2rem"}}
-   #_[file-upload/FileUploadButton {:id "upload-btn"
-                                    :on-drop #(e! (->UploadFiles %) #_(->TestFileUpload %))
-                                    :drop-message "Drop it like it's hot"}
-      "Click to upload"]])
+   [file-upload/FileUploadButton {:id "upload-btn"
+                                  :drag-container-id "file-upload-drag-container"
+                                  :on-drop #(e! (->UploadFiles %) #_(->TestFileUpload %))
+                                  :drop-message "Drop it like it's hot"}
+    "Click to upload"]])
 
 (defn- itemlist-demo []
   [:<>

--- a/app/frontend/src/cljs/teet/ui/component_demo.cljs
+++ b/app/frontend/src/cljs/teet/ui/component_demo.cljs
@@ -15,7 +15,8 @@
             [teet.log :as log]
             [reagent.core :as r]
             [teet.ui.rich-text-editor :as rich-text-editor]
-            [teet.ui.text-field :as text-field]))
+            [teet.ui.text-field :as text-field]
+            [teet.ui.mentions :as mentions]))
 
 (defrecord TestFileUpload [files])
 (defrecord UploadFiles [files])
@@ -260,6 +261,14 @@
   [:div
    [ui-common/labeled-data {:label "Label" :data "Some textual data"}]])
 
+(defn- mentions-demo [e!]
+  (r/with-let [state (r/atom "Hey @[Carla Consultant](ccbedb7b-ab30-405c-b389-292cdfe85271) how are you?")]
+    (println "STATE:" @state)
+    [mentions/mentions-input
+     {:e! e!
+      :value @state
+      :on-change #(reset! state (-> % .-target .-value))}]))
+
 (def demos
   [{:id :rte
     :heading "Rich text editor"
@@ -293,7 +302,10 @@
     :component [labeled-data-demo]}
    {:id :container
     :heading "Container"
-    :component [container-demo]}])
+    :component [container-demo]}
+   {:id :mentions
+    :heading "Mentions input"
+    :component [mentions-demo]}])
 
 (defn demo
   [e! {query :query :as _app}]
@@ -308,5 +320,5 @@
        ^{:key (str id)}
        [:div
         [Heading2 heading]
-        component
+        (conj component e!)
         [Divider {:style {:margin "2rem 0"}}]])]))

--- a/app/frontend/src/cljs/teet/ui/component_demo.cljs
+++ b/app/frontend/src/cljs/teet/ui/component_demo.cljs
@@ -262,12 +262,21 @@
    [ui-common/labeled-data {:label "Label" :data "Some textual data"}]])
 
 (defn- mentions-demo [e!]
-  (r/with-let [state (r/atom "Hey @[Carla Consultant](ccbedb7b-ab30-405c-b389-292cdfe85271) how are you?")]
-    (println "STATE:" @state)
-    [mentions/mentions-input
-     {:e! e!
-      :value @state
-      :on-change #(reset! state (-> % .-target .-value))}]))
+  (r/with-let [empty-state (r/atom "")
+               existing-state (r/atom "Hey @[Carla Consultant](ccbedb7b-ab30-405c-b389-292cdfe85271) how are you?")]
+    [:<>
+     [:div {:data-cy "mentions-empty"}
+      "Mentions with initially empty data: "
+      [mentions/mentions-input
+       {:e! e!
+        :value @empty-state
+        :on-change #(reset! empty-state (-> % .-target .-value))}]]
+     [:div {:data-cy "mentions-existing"}
+      "Mentions with existing data: "
+      [mentions/mentions-input
+       {:e! e!
+        :value @existing-state
+        :on-change #(reset! existing-state (-> % .-target .-value))}]]]))
 
 (def demos
   [{:id :rte

--- a/app/frontend/src/cljs/teet/ui/mentions.cljs
+++ b/app/frontend/src/cljs/teet/ui/mentions.cljs
@@ -32,41 +32,49 @@
           [:span {:class (<class common-styles/label-text-style)}
            label (when required
                    [common/required-astrix])]
-          [MentionsInput {:value value
-                          :id id
-                          :on-focus (fn [_]
-                                      (reset! caret (.-selectionStart @input-ref)))
-                          :on-change (fn [e new-value new-plain-text-value new-mentions]
-                                       (let [old-mention-ids (into #{} (map #(aget % "id")) @old-mentions)
-                                             new-mention-ids (into #{} (map #(aget % "id")) new-mentions)
-                                             added-mention (first (set/difference new-mention-ids old-mention-ids))
-                                             removed-mention (first (set/difference old-mention-ids new-mention-ids))]
-                                         (reset! caret
-                                                 (cond
-                                                   ;; Mention added: move caret after it
-                                                   added-mention
-                                                   (some #(when (= (aget % "id") added-mention)
-                                                            (+ (aget % "plainTextIndex")
-                                                               (count (aget % "display")))) new-mentions)
+          [MentionsInput
+           {:value value
+            :id id
+            :on-focus (fn [_]
+                        (reset! caret (.-selectionStart @input-ref)))
+            :on-change (fn [e _new-value new-plain-text-value new-mentions]
+                         (let [new-mention-ids (into #{} (map #(aget % "id")) new-mentions)
+                               current-old-mentions @old-mentions
+                               old-mention-ids (if (nil? current-old-mentions)
+                                                 ;; First change, old mentions not initialized yet
+                                                 ;; Use the new mentions
+                                                 new-mention-ids
 
-                                                   ;; Mention removed: move caret at it's start index
-                                                   removed-mention
-                                                   (some #(when (= (aget % "id") removed-mention)
-                                                            (aget % "plainTextIndex")) @old-mentions)
+                                                 ;; Use old mentions from previous edit
+                                                 (into #{} (map #(aget % "id")) current-old-mentions))
+                               added-mention (first (set/difference new-mention-ids old-mention-ids))
+                               removed-mention (first (set/difference old-mention-ids new-mention-ids))]
+                           (reset! caret
+                                   (cond
+                                     ;; Mention added: move caret after it
+                                     added-mention
+                                     (some #(when (= (aget % "id") added-mention)
+                                              (+ (aget % "plainTextIndex")
+                                                 (count (aget % "display")))) new-mentions)
 
-                                                   ;; No mentions changed, keep caret at current position
-                                                   :else
-                                                   (.-selectionStart @input-ref)))
-                                         (reset! old-mentions new-mentions))
-                                       (on-change e)
-                                       (when (not= (count new-plain-text-value)
-                                                   @caret)
-                                         ;; Flush forces re-render did-update call
-                                         ;; Otherwise there would be situations in which the change is fired twice
-                                         ;; without a call to did-update
-                                         (r/flush)))
-                          :input-ref #(reset! input-ref %)
-                          :class-name "comment-textarea"}
+                                     ;; Mention removed: move caret at it's start index
+                                     removed-mention
+                                     (some #(when (= (aget % "id") removed-mention)
+                                              (aget % "plainTextIndex")) @old-mentions)
+
+                                     ;; No mentions changed, keep caret at current position
+                                     :else
+                                     (.-selectionStart @input-ref)))
+                           (reset! old-mentions new-mentions))
+                         (on-change e)
+                         (when (not= (count new-plain-text-value)
+                                     @caret)
+                           ;; Flush forces re-render did-update call
+                           ;; Otherwise there would be situations in which the change is fired twice
+                           ;; without a call to did-update
+                           (r/flush)))
+            :input-ref #(reset! input-ref %)
+            :class-name "comment-textarea"}
            [Mention {:trigger "@"
                      :display-transform (fn [_ display]
                                           (str "@" display))

--- a/ci/browser-tests/cypress/integration/mentions.spec.js
+++ b/ci/browser-tests/cypress/integration/mentions.spec.js
@@ -1,0 +1,35 @@
+context("Mentions input", function() {
+    before(() => {
+        cy.dummyLogin("carla")
+        cy.visit("#/components?show=mentions")
+    })
+
+    it("Empty input", () => {
+
+        let sel = "[data-cy='mentions-empty'] textarea"
+
+        cy.get(sel).type("testing @da")
+
+        // expect suggestion for danny d manager to be present
+        cy.get(sel).get(".comment-textarea__suggestions__item").contains("Danny D. Manager").click()
+
+        cy.get(sel).should("have.value", "testing @Danny D. Manager")
+
+        // type 1 backspace and it should clear the whole mention
+        cy.get(sel).type("{backspace}")
+        cy.get(sel).should("have.value", "testing ")
+
+    })
+
+    it("Existing input", () => {
+
+        let sel = "[data-cy='mentions-existing'] textarea"
+
+        cy.get(sel).should("have.value", "Hey @Carla Consultant how are you?")
+
+        // type more text, it should go in the end (tests for caret jumping bug)
+        cy.get(sel).type(" More text")
+        cy.get(sel).should("have.value", "Hey @Carla Consultant how are you? More text")
+
+    })
+})


### PR DESCRIPTION
Fixes bug in mentions input where editing an input whose initial value already contained a mention would cause the caret to jump to the end of the mention.

Added cypress test for mentions.