### PR TITLE
TEET-1047 Don't include old file versions when checking for task part emptiness

### DIFF
--- a/app/backend/src/clj/teet/file/file_tx.clj
+++ b/app/backend/src/clj/teet/file/file_tx.clj
@@ -54,7 +54,12 @@
                           :in $ ?part
                           :where
                           [?file :file/part ?part]
-                          [(missing? $ ?file :meta/deleted?)]]
+                          ;; File is not deleted
+                          [(missing? $ ?file :meta/deleted?)]
+
+                          ;; File has not been replaced with newer version
+                          (not-join [?file]
+                                    [?replacement :file/previous-version ?file])]
                         db part-id)
                    (mapv first))]
     (if (seq files)


### PR DESCRIPTION
Task parts can't be deleted if they contain files.
This check also took into account files that have been replaced and the newer version placed to another part.

Change query to disregard replaced files and add test for this flow.