### PR TITLE
fix situation with conflicting repeatable/non-repeatable migrations & dropped functions

### DIFF
--- a/db/src/main/resources/db/migration/R__04_entity.sql
+++ b/db/src/main/resources/db/migration/R__04_entity.sql
@@ -154,3 +154,13 @@ SELECT ST_AsGML(ST_FlipCoordinates(ST_Collect(x.geometry)))
 $$ LANGUAGE SQL SECURITY DEFINER;
 
 GRANT EXECUTE ON FUNCTION teet.gml_entity_search_area(BIGINT,INTEGER) TO teet_backend;
+
+-- unneeded function, but since a checksummed non-repeatable function tries to DROP it, have to leave this stub here:
+CREATE OR REPLACE FUNCTION teet.replace_entity_ids(idlist TEXT)
+RETURNS BOOLEAN
+AS $$
+DECLARE
+BEGIN
+  RETURN false;
+END;
+$$ LANGUAGE PLPGSQL SECURITY DEFINER;

--- a/db/src/main/resources/db/migration/V17__remove_unused_rpc.sql
+++ b/db/src/main/resources/db/migration/V17__remove_unused_rpc.sql
@@ -1,1 +1,1 @@
-DROP FUNCTION IF EXISTS teet.replace_entity_ids(TEXT);
+DROP FUNCTION teet.replace_entity_ids(TEXT);


### PR DESCRIPTION
A function defn (replace_entity_ids) had been removed from the repeatable migrations, and a non-repeatable migration tried to drop it unconditionally. This errored, but changing the nr migration caused a checksum error.

Restore the function in a repeatable migration in placeholder form.