### PR TITLE
Teet-1163 fixes deactivated users being shown in user search

### DIFF
--- a/app/backend/src/clj/teet/user/user_queries.clj
+++ b/app/backend/src/clj/teet/user/user_queries.clj
@@ -9,6 +9,7 @@
          :where
          [?e :user/id _]
          [?e :user/given-name ?given]
+         [(missing? $ ?e :user/deactivated?)]
          [?e :user/family-name ?family]
          [(str ?given " " ?family) ?full-name]
          [(.toLowerCase ?full-name) ?full-name-lower]


### PR DESCRIPTION
Adds a check to user search to not include deactivated users.