### PR TITLE
TEET-1026 Only show sequence number files whose task has not been deleted

### DIFF
--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -250,6 +250,9 @@
 
                 ;; File belongs to the project
                 [?task :task/files ?f]
+                ;; Earlier it was possible to delete a task without deleting the files first.
+                ;; We don't want to list the files whose task has been deleted.
+                (not [?task :meta/deleted? true])
                 [?act :activity/tasks ?task]
                 [?act :activity/name :activity.name/land-acquisition]
                 [?lc :thk.lifecycle/activities ?act]

--- a/app/backend/src/clj/teet/file/file_db.clj
+++ b/app/backend/src/clj/teet/file/file_db.clj
@@ -252,7 +252,7 @@
                 [?task :task/files ?f]
                 ;; Earlier it was possible to delete a task without deleting the files first.
                 ;; We don't want to list the files whose task has been deleted.
-                (not [?task :meta/deleted? true])
+                [(missing? $ ?task :meta/deleted?)]
                 [?act :activity/tasks ?task]
                 [?act :activity/name :activity.name/land-acquisition]
                 [?lc :thk.lifecycle/activities ?act]


### PR DESCRIPTION
This PR ensures that files of deleted tasks are not shown in the cadastral unit info dialog. It is no longer possible to delete tasks that have undeleted files. However, there are tasks deleted before the restriction that do contain files.

I didn't add any tests as it isn't possible to introduce the situation that this PR fixes without directly setting the task's `:meta/deleted?` attribute in the database.