### PR TITLE
TEET-1162 fixes drop-zone issue in cooperation view

### DIFF
--- a/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
+++ b/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
@@ -457,6 +457,15 @@
        [:div {:class (<class common-styles/margin-bottom 1)}
         [rich-text-editor/display-markdown
          (:cooperation.response/content response)]]
+       [task-view/task-file-upload {:e! e!
+                                    :controls controls
+                                    :task related-task
+                                    :linked-from [:cooperation.response (:db/id response)]
+                                    :activity (:cooperation.application/activity application)
+                                    :project-id (:thk.project/id project)
+                                    :drag-container-id "drag-container-id"
+                                    :new-document new-document
+                                    :files-form files-form}]
        (authorization-context/consume
         (fn [authz]
           (let [can-upload? (boolean (and (some? related-task)
@@ -474,16 +483,7 @@
                             no-response?
                             {:title (tr [:cooperation :error :upload-not-allowed])
                              :body (tr [:cooperation :error :response-not-given])})]
-            [:div#drag-container-id
-             [task-view/task-file-upload {:e! e!
-                                          :controls controls
-                                          :task related-task
-                                          :linked-from [:cooperation.response (:db/id response)]
-                                          :activity (:cooperation.application/activity application)
-                                          :project-id (:thk.project/id project)
-                                          :drag-container-id "drag-container-id"
-                                          :new-document new-document
-                                          :files-form files-form}]
+            [:div {:id (when can-upload? :drag-container-id)}
              (if (empty? linked-files)
                [common/popper-tooltip error-msg
                 [buttons/button-primary {:size :small
@@ -542,7 +542,7 @@
      :button-component button-component}]])
 
 (defn- application-conclusion [e! {:cooperation.application/keys [opinion] :as application}]
-  [:<>
+  [:div {:class (<class common-styles/margin-bottom 1)}
    [:div.application-conclusion {:class (<class common-styles/margin-bottom 1)}
     [typography/Heading2 {:class (<class common-styles/margin-bottom 1)}
      (tr [:cooperation :opinion-title])]

--- a/app/frontend/src/cljs/teet/ui/drag.cljs
+++ b/app/frontend/src/cljs/teet/ui/drag.cljs
@@ -77,19 +77,19 @@
     #(reset! drag-state state)))
 
 (defn drop-zone [{:keys [element-id label on-drop]}]
-  (let [pos (-> element-id
-                js/document.getElementById
-                .getClientRects
-                (aget 0))]
-
-    [:div.drop-zone {:style {:left (aget pos "left")
-                             :top (aget pos "top")
-                             :width (aget pos "width")
-                             :height (aget pos "height")}
-                     :class (<class drop-zone-style)
-                     :on-drop (on-drop-f on-drop)
-                     :on-drag-over cancel}
-     label]))
+  (let [pos (some-> element-id
+                    js/document.getElementById
+                    .getClientRects
+                    (aget 0))]
+    (when pos
+      [:div.drop-zone {:style {:left (aget pos "left")
+                               :top (aget pos "top")
+                               :width (aget pos "width")
+                               :height (aget pos "height")}
+                       :class (<class drop-zone-style)
+                       :on-drop (on-drop-f on-drop)
+                       :on-drag-over cancel}
+       label])))
 
 (defn drag-handler
   "Global drag&drop handler. Should be rendered as part


### PR DESCRIPTION
File upload form being inside the authorization-context made it re-render on every form change, also if given id doesn't exist then the whole page went white, so using some-> instead of ->, indicates properly that no drop zone exists.