### PR TITLE
TEET-1162 check that files can be uploaded to cooperation task

### DIFF
--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -189,7 +189,7 @@
   :error
   {:upload-not-allowed "Upload not allowed",
    :coordination-task-missing
-   "Coordination task does not exist for the activity.",
+   "Coordination task does not exist for the activity, or it is in a state that does not allow file uploading.",
    :response-not-given "Files can be added after response is added",
    :coordination-task-status-mismatch
    "Task is not in a state that allows file upload.",

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -188,7 +188,8 @@
   :new-third-party-title "Kaasatud osapoole lisamine",
   :error
   {:upload-not-allowed "Üleslaadimine pole lubatud",
-   :coordination-task-missing "Tegevusel puudub kooskõlastusülesanne.",
+   :coordination-task-missing
+   "Tegevusel puudub kooskõlastusülesanne või ülesande staatus ei luba failide lisamist.",
    :response-not-given "Faile saab lisada peale vastuse lisamist",
    :coordination-task-status-mismatch
    "Ülesanne ei ole failide üleslaadimist lubavas olekus.",


### PR DESCRIPTION
fixes issue where button is enabled but files can't be uploaded to the cooperation response becasue the task doesn't allow file uploading.