### PR TITLE
TEET-1203 large text support for rich text fields

### DIFF
--- a/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
+++ b/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
@@ -15,12 +15,6 @@
             [teet.db-api.db-api-large-text :as db-api-large-text]
             [teet.environment :as environment]))
 
-(defn- store-large-text! [form]
-  (db-api-large-text/store-large-text!
-   (environment/api-context)
-   cooperation-model/rich-text-fields
-   form))
-
 (defn- third-party-is-new-or-belongs-to-project?
   "Check :db/id of new 3rd party form data and check if it is
   new (string) or already belongs to the project."
@@ -125,7 +119,8 @@
    :authorization {:cooperation/application-approval {}}
    :pre [(response-id-matches db application-id (:db/id response-payload))]
    :transact
-   (store-large-text!
+   (db-api-large-text/store-large-text!
+    cooperation-model/rich-text-fields
     (let [existing-id (:db/id response-payload)
           response-id (or existing-id "new-application-response")
           old-response (if existing-id

--- a/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
+++ b/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
@@ -168,7 +168,8 @@
    :authorization {:cooperation/application-approval {}}
    :pre [(opinion-id-matches db application-id (:db/id opinion-form))]
    :transact
-   (store-large-text!
+   (db-api-large-text/store-large-text!
+    cooperation-model/rich-text-fields
     [{:db/id application-id
       :cooperation.application/opinion
       (merge

--- a/app/backend/src/clj/teet/cooperation/cooperation_queries.clj
+++ b/app/backend/src/clj/teet/cooperation/cooperation_queries.clj
@@ -10,12 +10,6 @@
             [teet.db-api.db-api-large-text :as db-api-large-text]
             [teet.environment :as environment]))
 
-(defn- with-large-text [form]
-  (db-api-large-text/with-large-text
-    (environment/api-context)
-    cooperation-model/rich-text-fields
-    form))
-
 (defquery :cooperation/overview
   {:doc "Fetch project overview of cooperation: 3rd parties and their latest applications"
    :context {:keys [db user]}
@@ -54,7 +48,8 @@
           application-teet-id :application-teet-id}
    :project-id [:thk.project/id project-id]
    :authorization {:cooperation/view-cooperation-page {}}}
-  (with-large-text
+  (db-api-large-text/with-large-text
+    cooperation-model/rich-text-fields
     (let [p [:thk.project/id project-id]
           tp-id (cooperation-db/third-party-by-teet-id db third-party-teet-id)
           app-id (cooperation-db/application-by-teet-id db application-teet-id)]

--- a/app/backend/src/clj/teet/db_api/db_api_large_text.clj
+++ b/app/backend/src/clj/teet/db_api/db_api_large_text.clj
@@ -1,0 +1,66 @@
+(ns teet.db-api.db-api-large-text
+  "Large text support, stores large text values outside of Datomic."
+  (:require [teet.integration.postgrest :as postgrest]
+            [teet.util.collection :as cu]))
+
+(def ^:private hash-pattern #"^\[([A-Za-z0-9]+)\]$")
+
+(defn ->hash [str]
+  (when-let [[_ hash] (re-matches hash-pattern str)]
+    hash))
+
+(defn with-large-text
+  "Fill in large text values in form.
+
+  ctx contains a map with PostgREST API configuration
+  large-text-keys is a set of large text keywords
+  form is arbitrary nested Clojure data
+
+  Walks form and collects and replaces all values for large-text-keys
+  that contain a hash with the contents of that hash. Other values
+  are left as is."
+
+  [ctx large-text-keys form]
+  (cu/replace-deep
+   (fn [x no-replacement]
+     (if-let [hash (and (map-entry? x)
+                        (large-text-keys (first x))
+                        (->hash (second x)))]
+       [(first x)
+        (postgrest/rpc ctx :fetch_large_text {:hash hash})]
+       no-replacement))
+   form))
+
+(def ^{:doc "Threshold text length over which to store externally"
+       :private true}
+  storage-length-threshold 1024)
+
+(defn store-large-text!
+  "Store any large values for large-text-keys in PostgREST and replace them with
+  their hash. If a value is already a hash, it is not touched.
+
+  This must be called on data containing large text values before storing
+  it in Datomic.
+
+  ctx contains a map with PostgREST API configuration
+  large-text-kes is a set of large text keywords
+  form is arbitrary Clojure data.
+
+  Returns updated form.
+  "
+
+  [ctx large-text-keys form]
+  (cu/replace-deep
+   (fn [x no-replacement]
+     (if (and (map-entry? x)
+              (large-text-keys (first x))
+              (not (->hash (second x)))
+              (string? (second x))
+              (> (count (second x)) storage-length-threshold))
+       (let [new-hash
+             ;; Store new text
+             (postgrest/rpc ctx :store_large_text
+                            {:text (second x)})]
+         [(first x) (str "[" new-hash "]")])
+       no-replacement))
+   form))

--- a/app/backend/src/clj/teet/integration/integration_s3.clj
+++ b/app/backend/src/clj/teet/integration/integration_s3.clj
@@ -5,7 +5,7 @@
             [cheshire.core :as cheshire]
             [cognitect.aws.client.api :as aws]
             [cognitect.aws.credentials :as aws-credentials]
-            [clojure.string :as str]))
+            [teet.util.hash :refer [sha256 hex]]))
 
 (def ^:private s3-client (delay (aws/client {:api :s3})))
 
@@ -165,9 +165,7 @@
   (defn- timestamp [d]
     (.format fmt d)))
 
-(defn- hex [bytes]
-  (str/join ""
-            (map #(format "%02x" %) bytes)))
+
 
 (defn- ->b [string]
   (.getBytes string "UTF-8"))
@@ -177,10 +175,6 @@
         mac (doto (javax.crypto.Mac/getInstance "HmacSHA256")
               (.init secret-key))]
     (.doFinal mac content-bytes)))
-
-(defn- sha256 [bytes]
-  (let [d (java.security.MessageDigest/getInstance "SHA-256")]
-    (.digest d bytes)))
 
 (def credentials-provider (aws-credentials/cached-credentials-with-auto-refresh
                            (aws-credentials/default-credentials-provider (aws/default-http-client))))

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -385,11 +385,13 @@
    :project-id (project-db/decision-project-id db (:db/id form-data))
    :authorization {:meeting/edit-meeting {:db/id (meeting-db/decision-meeting-id db (:db/id form-data))
                                           :link :meeting/organizer-or-reviewer}}
-   :transact (update-meeting-tx
-               user
-               (meeting-db/decision-meeting-id db (:db/id form-data))
-               [(merge (select-keys form-data [:meeting.decision/body :db/id])
-                       (meta-model/modification-meta user))])})
+   :transact
+   (store-large-text!
+    (update-meeting-tx
+     user
+     (meeting-db/decision-meeting-id db (:db/id form-data))
+     [(merge (select-keys form-data [:meeting.decision/body :db/id])
+             (meta-model/modification-meta user))]))})
 
 (defcommand :meeting/delete-decision
   {:doc "Mark a given decision as deleted"

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -379,7 +379,8 @@
    :authorization {:meeting/edit-meeting {:db/id (meeting-db/decision-meeting-id db (:db/id form-data))
                                           :link :meeting/organizer-or-reviewer}}
    :transact
-   (store-large-text!
+   (db-api-large-text/store-large-text!
+    meeting-model/rich-text-fields
     (update-meeting-tx
      user
      (meeting-db/decision-meeting-id db (:db/id form-data))

--- a/app/backend/src/clj/teet/meeting/meeting_commands.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_commands.clj
@@ -21,14 +21,6 @@
             [teet.db-api.db-api-large-text :as db-api-large-text])
   (:import (java.util Date)))
 
-(defn- store-large-text! [form]
-  (db-api-large-text/store-large-text!
-   (environment/api-context)
-   meeting-model/rich-text-fields
-   form))
-
-
-
 (defn update-meeting-tx
   [user meeting-id tx-data]
   [(list 'teet.meeting.meeting-tx/update-meeting
@@ -170,7 +162,8 @@
                                           :link :meeting/organizer-or-reviewer}}
    :pre [(agenda-items-new-or-belong-to-meeting db meeting-id agenda)]
    :transact
-   (store-large-text!
+   (db-api-large-text/store-large-text!
+    meeting-model/rich-text-fields
     (update-meeting-tx
      user
      meeting-id

--- a/app/backend/src/clj/teet/meeting/meeting_queries.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_queries.clj
@@ -21,12 +21,6 @@
             [teet.entity.entity-db :as entity-db]
             [teet.db-api.db-api-large-text :as db-api-large-text]))
 
-(defn- with-large-text! [form]
-  (db-api-large-text/with-large-text
-    (environment/api-context)
-    meeting-model/rich-text-fields
-    form))
-
 (defn project-related-unit-ids
   [db api-context project-eid]
   (let [units (:thk.project/related-cadastral-units (datomic-util/entity db project-eid))]
@@ -250,7 +244,8 @@
    :authorization {:project/read-info {:eid (project-db/activity-project-id db activity-id)
                                        :link :thk.project/owner
                                        :access :read}}}
-  (with-large-text!
+  (db-api-large-text/with-large-text
+    meeting-model/rich-text-fields
     (let [valid-external-ids (project-related-unit-ids db (environment/api-context) (project-db/activity-project-id db activity-id))]
       (link-db/fetch-links
        db user

--- a/app/backend/src/clj/teet/util/hash.clj
+++ b/app/backend/src/clj/teet/util/hash.clj
@@ -1,0 +1,23 @@
+(ns teet.util.hash
+  (:import (java.security MessageDigest))
+  (:require [clojure.string :as str]))
+
+(defn- ->bytes [x]
+  (cond
+    (bytes? x) x
+    (string? x) (.getBytes x "UTF-8")
+    :else (throw (ex-info "Don't know how to turn into bytes"
+                          {:unknown-value x}))))
+
+(defn sha256
+  "Create SHA256 hash of byte array or string.
+  Returns hash as a byte array."
+  [x]
+  (let [d (MessageDigest/getInstance "SHA-256")]
+    (.digest d (->bytes x))))
+
+(defn hex
+  "Format byte array as a hex string"
+  [bytes]
+  (str/join ""
+            (map #(format "%02x" %) bytes)))

--- a/app/backend/test/teet/db_api/db_api_large_text_test.clj
+++ b/app/backend/test/teet/db_api/db_api_large_text_test.clj
@@ -12,15 +12,16 @@
   (fn [tests]
     (reset! large-text {})
     ;; Mock PostgREST as we don't have it in CI tests
-    (with-redefs [postgrest/rpc (fn [_ name {:keys [text hash]}]
-                                  (case name
-                                    :fetch_large_text
-                                    (@large-text hash)
+    (with-redefs [postgrest/rpc
+                  (fn [_ name {:keys [text hash]}]
+                    (case name
+                      :fetch_large_text
+                      (@large-text hash)
 
-                                    :store_large_text
-                                    (let [h (hex (sha256 text))]
-                                      (swap! large-text assoc h text)
-                                      h)))]
+                      :store_large_text
+                      (let [h (hex (sha256 text))]
+                        (swap! large-text assoc h text)
+                        h)))]
       (tests))))
 
 (deftest small-text

--- a/app/backend/test/teet/db_api/db_api_large_text_test.clj
+++ b/app/backend/test/teet/db_api/db_api_large_text_test.clj
@@ -1,0 +1,46 @@
+(ns ^:db teet.db-api.db-api-large-text-test
+  (:require [teet.db-api.db-api-large-text :refer [with-large-text store-large-text!]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [teet.integration.postgrest :as postgrest]
+            [teet.util.hash :refer [sha256 hex]]
+            [clojure.string :as str]))
+
+(def large-text (atom {}))
+(def ctx {}) ;; dummy ctx
+
+(use-fixtures :each
+  (fn [tests]
+    (reset! large-text {})
+    ;; Mock PostgREST as we don't have it in CI tests
+    (with-redefs [postgrest/rpc (fn [_ name {:keys [text hash]}]
+                                  (case name
+                                    :fetch_large_text
+                                    (@large-text hash)
+
+                                    :store_large_text
+                                    (let [h (hex (sha256 text))]
+                                      (swap! large-text assoc h text)
+                                      h)))]
+      (tests))))
+
+(deftest small-text
+  (testing "Small text is not stored"
+    (is (= (store-large-text! ctx #{:text}
+                              {:text "hello"})
+           {:text "hello"}))
+    (is (empty? @large-text))))
+
+(def gen-chars (into [" "]
+                     (map (comp str char))
+                     (range (int \a) (int \z))))
+
+(deftest large-text-stored
+  (testing "Large text is stored"
+    (let [text (str/join (repeatedly 2000 #(rand-nth gen-chars)))
+          stored (store-large-text! ctx #{:text}
+                                    {:text text})]
+      (is (str/starts-with? (:text stored) "["))
+      (is (str/ends-with? (:text stored) "]"))
+      (is (= text (-> @large-text first val)))
+      (is (= {:text text}
+             (with-large-text ctx #{:text} stored))))))

--- a/app/common/src/cljc/teet/cooperation/cooperation_model.cljc
+++ b/app/common/src/cljc/teet/cooperation/cooperation_model.cljc
@@ -134,3 +134,5 @@
 
 (defn editable? [application]
   (not (contains? application :cooperation.application/opinion)))
+
+(def rich-text-fields #{:cooperation.response/content :cooperation.opinion/comment})

--- a/app/common/src/cljc/teet/meeting/meeting_model.cljc
+++ b/app/common/src/cljc/teet/meeting/meeting_model.cljc
@@ -41,3 +41,5 @@
                   (= (:db/id user)
                      (get-in % [:participation/participant :db/id])))
             (:participation/_in meeting))))
+
+(def rich-text-fields #{:meeting.agenda/body :meeting.decision/body})

--- a/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
+++ b/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
@@ -457,9 +457,7 @@
                                 {:thk.project/id project-id
                                  :application-id application-id
                                  :form-data (common-controller/prepare-form-data
-                                              (rich-text-editor/form-data-with-rich-text
-                                                :cooperation.response/content
-                                                @form-atom))}
+                                             (form/serialize @form-atom))}
                                 (fn [response]
                                   (fn [e!]
                                     (e! (close-event))
@@ -591,7 +589,7 @@
     :cancel-event close-event
     :save-event #(cooperation-controller/save-opinion-event
                   application
-                  (rich-text-editor/form-data-with-rich-text :cooperation.opinion/comment @form-atom)
+                  (form/serialize @form-atom)
                   close-event)
     :spec ::cooperation-model/opinion-form}
    ^{:attribute :cooperation.opinion/status :xs 10}

--- a/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
+++ b/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
@@ -457,7 +457,7 @@
                                 {:thk.project/id project-id
                                  :application-id application-id
                                  :form-data (common-controller/prepare-form-data
-                                             (form/serialize @form-atom))}
+                                             (form/to-value @form-atom))}
                                 (fn [response]
                                   (fn [e!]
                                     (e! (close-event))
@@ -589,7 +589,7 @@
     :cancel-event close-event
     :save-event #(cooperation-controller/save-opinion-event
                   application
-                  (form/serialize @form-atom)
+                  (form/to-value @form-atom)
                   close-event)
     :spec ::cooperation-model/opinion-form}
    ^{:attribute :cooperation.opinion/status :xs 10}

--- a/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
+++ b/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
@@ -623,7 +623,7 @@
                       :spec :meeting/agenda-form
                       :save-event #(meeting-controller/->SubmitAgendaForm
                                      meeting
-                                     (rich-text-editor/form-data-with-rich-text :meeting.agenda/body @form-atom)
+                                     (form/serialize @form-atom)
                                      close-event)}
                      (when-let [agenda-id (:db/id @form-atom)]
                        {:delete (meeting-controller/->DeleteAgendaTopic agenda-id close-event)}))
@@ -826,7 +826,7 @@
                       :spec :meeting/decision-form
                       :save-event #(meeting-controller/->SubmitDecisionForm
                                      agenda-eid
-                                     (rich-text-editor/form-data-with-rich-text :meeting.decision/body @form-atom)
+                                     (form/serialize @form-atom)
                                      close-event)}
                      (when (:db/id @form-atom)
                        {:delete (meeting-controller/->DeleteDecision (:db/id @form-atom) close-event)}))

--- a/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
+++ b/app/frontend/src/cljs/teet/meeting/meeting_view.cljs
@@ -623,7 +623,7 @@
                       :spec :meeting/agenda-form
                       :save-event #(meeting-controller/->SubmitAgendaForm
                                      meeting
-                                     (form/serialize @form-atom)
+                                     (form/to-value @form-atom)
                                      close-event)}
                      (when-let [agenda-id (:db/id @form-atom)]
                        {:delete (meeting-controller/->DeleteAgendaTopic agenda-id close-event)}))
@@ -826,7 +826,7 @@
                       :spec :meeting/decision-form
                       :save-event #(meeting-controller/->SubmitDecisionForm
                                      agenda-eid
-                                     (form/serialize @form-atom)
+                                     (form/to-value @form-atom)
                                      close-event)}
                      (when (:db/id @form-atom)
                        {:delete (meeting-controller/->DeleteDecision (:db/id @form-atom) close-event)}))

--- a/app/frontend/src/cljs/teet/project/project_controller.cljs
+++ b/app/frontend/src/cljs/teet/project/project_controller.cljs
@@ -123,7 +123,6 @@
 (defrecord DrawSelectionCancel [])
 
 
-(defrecord OpenEditTaskDialog [task-id])
 (defrecord OpenEditActivityDialog [activity-id])
 
 (defrecord DeleteActivity [activity-id])
@@ -744,15 +743,6 @@
                (-> app common-controller/page-state
                    (project-model/activity-by-id activity-id)
                    (update :activity/name :db/ident)))))
-
-  OpenEditTaskDialog
-  (process-event [{task-id :task-id} app]
-    (-> app
-        (assoc-in [:stepper :dialog] {:type :edit-task})
-        (assoc :edit-task-data
-               (-> app common-controller/page-state
-                   (project-model/task-by-id task-id)
-                   task->edit-task-data))))
 
   UpdateActivityState
   (process-event [{activity-id :id status :status} app]

--- a/app/frontend/src/cljs/teet/task/task_controller.cljs
+++ b/app/frontend/src/cljs/teet/task/task_controller.cljs
@@ -34,10 +34,6 @@
 (defrecord DeleteTaskResult [response])
 
 (defrecord OpenEditModal [entity])
-(defrecord UpdateEditTaskForm [form-data])
-(defrecord CancelTaskEdit [])
-(defrecord SaveTaskForm [])
-(defrecord SaveTaskSuccess [])
 
 (defrecord OpenAddDocumentDialog [])
 (defrecord CloseAddDocumentDialog [])
@@ -176,38 +172,6 @@
          :success-message (tr [:notifications :task-status-updated])
          :result-event     common-controller/->Refresh})))
 
-  UpdateEditTaskForm
-  (process-event [{form-data :form-data} app]
-    (update-in app [:edit-task-data] merge form-data))
-
-  CancelTaskEdit
-  (process-event [_ {:keys [page params query] :as app}]
-    (t/fx (-> app
-              (dissoc :edit-task-data)
-              (update :stepper dissoc :dialog))
-          {:tuck.effect/type :navigate
-           :page             page
-           :params           params
-           :query            (dissoc query :modal :add :edit :activity :lifecycle)}))
-
-  SaveTaskForm
-  (process-event [_ {edit-task-data :edit-task-data
-                     stepper :stepper :as app}]
-    (t/fx app
-          (merge
-           {:tuck.effect/type :command!
-            :result-event ->SaveTaskSuccess}
-           {:command :task/update
-            :payload (select-keys edit-task-data
-                                  task-model/edit-form-keys)
-            :success-message (tr [:notifications :task-updated])})))
-
-  SaveTaskSuccess
-  (process-event [_ {:keys [page query params] :as app}]
-    (t/fx (-> app
-              (dissoc :edit-task-data)
-              (update :stepper dissoc :dialog))
-          common-controller/refresh-fx))
 
   UpdateTask
   (process-event [{:keys [task updated-task]} app]

--- a/app/frontend/src/cljs/teet/task/task_controller.cljs
+++ b/app/frontend/src/cljs/teet/task/task_controller.cljs
@@ -26,9 +26,6 @@
                 (conj selected-task false))))))
 
 (defrecord UploadDocuments [files])
-(defrecord UpdateTask [task updated-task]) ; update task info to database
-(defrecord UpdateTaskResponse [response])
-(defrecord UpdateTaskStatus [status])
 
 (defrecord DeleteTask [task-id])
 (defrecord DeleteTaskResult [response])
@@ -160,35 +157,6 @@
              :task-id (common-controller/->long task)
              :project-id project
              :app-path [:task task :task/documents]})))
-
-  UpdateTaskStatus
-  (process-event [{status :status} app]
-    (let [task-id (get-in app [:params :task])]
-      (t/fx app
-        {:tuck.effect/type :command!
-         :command          :task/update
-         :payload          {:db/id (common-controller/->long task-id)
-                            :task/status status}
-         :success-message (tr [:notifications :task-status-updated])
-         :result-event     common-controller/->Refresh})))
-
-
-  UpdateTask
-  (process-event [{:keys [task updated-task]} app]
-    (let [id (:db/id task)
-          task-path  [:task (str id)]
-          new-task (merge task updated-task)]
-
-      (t/fx (assoc-in app task-path new-task)
-            {:tuck.effect/type :command!
-             :command          :task/update
-             :payload          (assoc updated-task :db/id id)
-             :result-event     ->UpdateTaskResponse})))
-
-  UpdateTaskResponse
-  (process-event [{response :response} app]
-    (log/info "GOT RESPONSE: " response)
-    app)
 
   OpenAddTasksDialog
   (process-event [{activity-id :activity-id} {:keys [page params query] :as app}]

--- a/app/frontend/src/cljs/teet/task/task_view.cljs
+++ b/app/frontend/src/cljs/teet/task/task_view.cljs
@@ -404,7 +404,7 @@
                  :cancel-event close-event
                  :save-event #(common-controller/->SaveForm
                                :task/update
-                               (form/serialize (select-keys @form-atom task-model/edit-form-keys))
+                               (form/to-value (select-keys @form-atom task-model/edit-form-keys))
                                (fn [_response]
                                  (fn [e!]
                                    (e! (close-event))

--- a/app/frontend/src/cljs/teet/task/task_view.cljs
+++ b/app/frontend/src/cljs/teet/task/task_view.cljs
@@ -34,7 +34,9 @@
             [teet.log :as log]
             [teet.ui.drag :as drag]
             [goog.string :as gstr]
-            [teet.authorization.authorization-check :as authorization-check]))
+            [teet.authorization.authorization-check :as authorization-check]
+            [teet.common.common-controller :as common-controller]
+            [teet.snackbar.snackbar-controller :as snackbar-controller]))
 
 
 (defn- task-groups-for-activity [activity-name task-groups]
@@ -390,48 +392,23 @@
          [buttons/button-primary {:on-click (e! task-controller/->Review :accept)}
           (tr [:task :accept-review])]]])]))
 
-(defn- task-header
-  [e! task]
-  [:div.task-header {:class (<class common-styles/heading-and-action-style)}
-   [typography/Heading1 (tr-enum (:task/type task))]
-   [when-authorized :task/update
-    task
-    [buttons/button-secondary {:on-click #(e! (project-controller/->OpenEditTaskDialog (:db/id task)))}
-     (tr [:buttons :edit])]]])
-
-(defn- start-review [e!]
-  (e! (task-controller/->StartReview))
-  (fn [_]
-    [:span]))
-
-(defn- task-page-content
-  [e! app activity {status :task/status :as task} pm? files-form]
-  [:div.task-page
-   (when (and pm? (du/enum= status :task.status/waiting-for-review))
-     [when-authorized :task/start-review task
-      [start-review e!]])
-   [task-header e! task]
-   [tabs/details-and-comments-tabs
-    {:e! e!
-     :app app
-     :type :task-comment
-     :entity-type :task
-     :entity-id (:db/id task)}
-    [task-details e! (:new-document app)
-     (get-in app [:params :project])
-     activity task files-form]]])
-
-
-(defn- edit-task-form [_e! {:keys [initialization-fn]} {:keys [max-date min-date]} allow-delete?]
-  (when initialization-fn
-    (initialization-fn))
-  (fn [e! {id :db/id send-to-thk? :task/send-to-thk? :as task}]
+(defn- edit-task-form [e! {:keys [max-date min-date allow-delete?]}
+                       close-event form-atom ]
+  (let [{id :db/id send-to-thk? :task/send-to-thk? :as task} @form-atom]
     [:div.edit-task-form
      [form/form {:e! e!
                  :value task
-                 :on-change-event task-controller/->UpdateEditTaskForm
-                 :cancel-event task-controller/->CancelTaskEdit
-                 :save-event task-controller/->SaveTaskForm
+                 :on-change-event (form/update-atom-event form-atom merge)
+                 :cancel-event close-event
+                 :save-event #(common-controller/->SaveForm
+                               :task/update
+                               (select-keys @form-atom task-model/edit-form-keys)
+                               (fn [_response]
+                                 (fn [e!]
+                                   (e! (close-event))
+                                   (e! (snackbar-controller/->OpenSnackBar
+                                        (tr [:notifications :task-updated]) :success))
+                                   (e! (common-controller/->Refresh)))))
                  :delete (when allow-delete?
                            (task-controller/->DeleteTask id))
                  :delete-message (when send-to-thk?
@@ -460,6 +437,58 @@
       ^{:attribute :task/assignee}
       [select/select-user {:e! e! :attribute :task/assignee}]]]))
 
+(defn- edit-task-form-button [e! activity task allow-delete?]
+  [form/form-modal-button
+   {:e! e!
+    :button-component [buttons/button-secondary {}
+                       (tr [:buttons :edit])]
+    :modal-title (tr [:project :edit-task])
+    :form-component [edit-task-form e!
+                     {:max-date (:activity/estimated-end-date activity)
+                      :min-date (:activity/estimated-start-date activity)
+                      :allow-delete? allow-delete?}]
+    :form-value task}])
+
+(defn- task-header
+  [e! activity task]
+  [:div.task-header {:class (<class common-styles/heading-and-action-style)}
+   [typography/Heading1 (tr-enum (:task/type task))]
+   [when-authorized :task/update
+    task
+    [authorization-check/with-authorization-check
+     (if (:task/send-to-thk? task)
+       :task/delete-task-sent-to-thk
+       :task/delete-task)
+     task
+
+     [edit-task-form-button e! activity task]]
+    ]])
+
+(defn- start-review [e!]
+  (e! (task-controller/->StartReview))
+  (fn [_]
+    [:span]))
+
+(defn- task-page-content
+  [e! app activity {status :task/status :as task} pm? files-form]
+  [:div.task-page
+   (when (and pm? (du/enum= status :task.status/waiting-for-review))
+     [when-authorized :task/start-review task
+      [start-review e!]])
+   [task-header e! activity task]
+   [tabs/details-and-comments-tabs
+    {:e! e!
+     :app app
+     :type :task-comment
+     :entity-type :task
+     :entity-id (:db/id task)}
+    [task-details e! (:new-document app)
+     (get-in app [:params :project])
+     activity task files-form]]])
+
+
+
+
 (defmethod project-navigator-view/project-navigator-dialog :add-tasks
   [{:keys [e! app project]} _dialog]
   (let [activity-id (get-in app [:add-tasks-data :db/id])
@@ -469,20 +498,6 @@
      activity
      {:max-date (:activity/estimated-end-date activity)
       :min-date (:activity/estimated-start-date activity)}]))
-
-(defmethod project-navigator-view/project-navigator-dialog :edit-task
-  [{:keys [e! app project] :as _opts}  _dialog]
-  (let [activity-id (get-in app [:params :activity])
-        activity (project-model/activity-by-id project activity-id)
-        task (:edit-task-data app)]
-    [authorization-check/with-authorization-check
-     (if (:task/send-to-thk? task)
-       :task/delete-task-sent-to-thk
-       :task/delete-task)
-     task
-     [edit-task-form e! task
-      {:max-date (:activity/estimated-end-date activity)
-       :min-date (:activity/estimated-start-date activity)}]]))
 
 (defn task-page [e! {{task-id :task :as _params} :params user :user :as app}
                  project]

--- a/app/frontend/src/cljs/teet/task/task_view.cljs
+++ b/app/frontend/src/cljs/teet/task/task_view.cljs
@@ -370,7 +370,8 @@
     ^{:key (str "task-content-" (:db/id task))}
     [:div#task-details-drop.task-details
      (when description
-       [typography/Paragraph description])
+       [typography/Paragraph
+        [rich-text-editor/display-markdown description]])
      [task-basic-info task]
      [task-file-view e! activity task (:upload! upload-controls) files-form project-id]
      [task-file-upload {:e! e!

--- a/app/frontend/src/cljs/teet/task/task_view.cljs
+++ b/app/frontend/src/cljs/teet/task/task_view.cljs
@@ -36,7 +36,8 @@
             [goog.string :as gstr]
             [teet.authorization.authorization-check :as authorization-check]
             [teet.common.common-controller :as common-controller]
-            [teet.snackbar.snackbar-controller :as snackbar-controller]))
+            [teet.snackbar.snackbar-controller :as snackbar-controller]
+            [teet.ui.rich-text-editor :as rich-text-editor]))
 
 
 (defn- task-groups-for-activity [activity-name task-groups]
@@ -402,7 +403,7 @@
                  :cancel-event close-event
                  :save-event #(common-controller/->SaveForm
                                :task/update
-                               (select-keys @form-atom task-model/edit-form-keys)
+                               (form/serialize (select-keys @form-atom task-model/edit-form-keys))
                                (fn [_response]
                                  (fn [e!]
                                    (e! (close-event))
@@ -420,7 +421,7 @@
                  :spec :task/edit-task-form}
 
       ^{:attribute :task/description}
-      [TextField {:full-width true :multiline true :rows 4 :maxrows 4}]
+      [rich-text-editor/rich-text-field {}]
 
       ^{:attribute [:task/estimated-start-date :task/estimated-end-date] :xs 12}
       [date-picker/date-range-input {:start-label (tr [:fields :task/estimated-start-date])

--- a/app/frontend/src/cljs/teet/ui/form.cljs
+++ b/app/frontend/src/cljs/teet/ui/form.cljs
@@ -15,7 +15,24 @@
             [clojure.set :as set]
             [teet.common.common-styles :as common-styles]
             [teet.ui.panels :as panels]
-            [teet.ui.common :as common]))
+            [teet.ui.common :as common]
+            [clojure.walk :as walk]))
+
+(defprotocol ToValue
+  :extend-via-metadata true
+  (to-value [this]
+    "Return the actual form value from this internal field state."))
+
+(defn serialize
+  "Turn form into serializable form that can be sent as payload.
+  Calls to-value on all internal field states."
+  [form]
+  (walk/prewalk
+   (fn [x]
+     (if (satisfies? ToValue x)
+       (to-value x)
+       x))
+   form))
 
 (def default-value
   "Mapping of component to default value. Some components don't want nil as the value (like text area)."

--- a/app/frontend/src/cljs/teet/ui/rich_text_editor.cljs
+++ b/app/frontend/src/cljs/teet/ui/rich_text_editor.cljs
@@ -142,18 +142,6 @@
   (js>
    (export-markdown/stateToMarkdown (.getCurrentContent editor-state))))
 
-(defn form-data-with-rich-text
-  "Given a key where the rich text is in the map and a map
-  returns a map which can be stored in the backend"
-  [rich-text-attr form]
-  (if-not (contains? form rich-text-attr)
-    form
-    (update form rich-text-attr
-            (fn [data]
-              (if (or (string? data) (nil? data))
-                data
-                (editor-state->markdown data))))))
-
 (defn validate-rich-text-form-field-not-empty
   [value]
   (when (or

--- a/ci/browser-tests/cypress/integration/meeting.ci.spec.js
+++ b/ci/browser-tests/cypress/integration/meeting.ci.spec.js
@@ -51,6 +51,7 @@ context("Meetings", () => {
 
         cy.selectByKeyword(".new-participant select", ":participation.role/reviewer")
         cy.get(".new-participant button[type=submit]").click()
+        cy.wait(500)
         cy.get(".participant-list").contains("Carla Consultant")
 
         cy.location().as("meeting")

--- a/db/src/main/resources/db/migration/V20__large_text.sql
+++ b/db/src/main/resources/db/migration/V20__large_text.sql
@@ -1,3 +1,20 @@
-CREATE TABLE teet.large_text (id UUID PRIMARY KEY, text TEXT);
+CREATE TABLE teet.large_text (hash bytea PRIMARY KEY, text TEXT);
+
+-- Function to upsert new text, returns hash
+CREATE FUNCTION teet.store_large_text(text TEXT) RETURNS TEXT
+AS $$
+INSERT INTO teet.large_text (hash,text)
+VALUES (sha256(convert_to($1::TEXT,'UTF-8')), $1)
+ON CONFLICT (hash) DO UPDATE SET hash=large_text.hash
+RETURNING encode(sha256(convert_to($1::TEXT,'UTF-8')),'hex');
+$$ LANGUAGE SQL;
+
+-- Function to fetch text by hash
+CREATE FUNCTION teet.fetch_large_text(hash TEXT) RETURNS TEXT
+AS $$
+SELECT lt.text FROM teet.large_text lt WHERE lt.hash=decode($1, 'hex')
+$$ LANGUAGE SQL IMMUTABLE;
 
 GRANT ALL ON TABLE teet.large_text TO teet_backend;
+GRANT EXECUTE ON FUNCTION teet.store_large_text(TEXT) TO teet_backend;
+GRANT EXECUTE ON FUNCTION teet.fetch_large_text(TEXT) TO teet_backend;

--- a/db/src/main/resources/db/migration/V20__large_text.sql
+++ b/db/src/main/resources/db/migration/V20__large_text.sql
@@ -1,0 +1,3 @@
+CREATE TABLE teet.large_text (id UUID PRIMARY KEY, text TEXT);
+
+GRANT ALL ON TABLE teet.large_text TO teet_backend;


### PR DESCRIPTION

Add external storage of large tex in PostgreSQL.

Currently the functionality must be explicitly invoked in commands (to store externally) and queries (to fetch from external).

Also :task/description was changed to rich text field and the form refactored.