### PR TITLE
TEET-620 minor changes for headings and when the query adds filters.

### DIFF
--- a/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
+++ b/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
@@ -444,10 +444,14 @@
     [:<>
      [:div {:class (<class common-styles/margin-bottom 1.5)}
       [:div {:class (<class common-styles/header-with-actions)}
-       [:div
-        [typography/Heading2 (tr [:cooperation :page-title])]
-        [typography/Heading3 {:class (<class common-styles/margin-bottom 1)}
-         (tr [:cooperation :all-third-parties])]]
+       [context/consume :query-filter
+        (fn [{:keys [value]}]
+          [:div
+           [typography/Heading2 (tr [:cooperation :page-title])]
+           [typography/Heading3 {:class (<class common-styles/margin-bottom 1)}
+            (if (not= (:shortcut value) :all-applications)
+              (tr [:cooperation :filter :newest-applications])
+              (tr [:cooperation :filter :all-applications]))]])]
        [form/form-modal-button
         {:max-width "sm"
          :form-component [third-party-form {:e! e!

--- a/app/frontend/src/cljs/teet/ui/query.cljs
+++ b/app/frontend/src/cljs/teet/ui/query.cljs
@@ -76,13 +76,16 @@
                                          :reset-filter reset-filter}
           (let [state (if state-path
                         state
-                        @state-atom)]
+                        @state-atom)
+                new-args (if (not-empty @filter-atom)
+                           (assoc args :filters (cu/without-empty-vals
+                                                  @filter-atom))
+                           args)]
             (when (or (not= @refresh-value refresh)
                       (not= @previous-args args))
               (reset! refresh-value refresh)
               (reset! previous-args args)
-              (e! (->Query query (assoc args :filters (cu/without-empty-vals
-                                                        @filter-atom)) state-path state-atom)))
+              (e! (->Query query new-args state-path state-atom)))
             (if (or state loading-state)
               ;; Results loaded, call the view
               (if simple-view


### PR DESCRIPTION
change titles to match filter keys in cooperation search. And don't add filter key if the filter atom is empty.