### PR TITLE
Wrap Datomic q in with extra validations in local dev use and tests

### DIFF
--- a/app/backend/src/clj/teet/db_api/db_api_dev.clj
+++ b/app/backend/src/clj/teet/db_api/db_api_dev.clj
@@ -1,15 +1,25 @@
 (ns teet.db-api.db-api-dev
   (:require [compojure.core :refer [routes GET POST]]
-            [teet.db-api.db-api-handlers :as db-api-handlers]))
+            [teet.db-api.db-api-handlers :as db-api-handlers]
+            [teet.util.datomic :as du]
+            [datomic.client.api :as d]))
+
+(defmacro with-query-checking [& body]
+  `(with-redefs [d/q (fn [& args#]
+                       (apply du/q args#))]
+     ~@body))
 
 (defn db-api-routes []
   (routes
    (POST "/query/" req
-         (#'db-api-handlers/query-handler req))
+     (with-query-checking
+       (#'db-api-handlers/query-handler req)))
 
    ;; FIXME: URL params are not handled currently
    (GET "/query/" req
-        (#'db-api-handlers/query-handler req))
+     (with-query-checking
+       (#'db-api-handlers/query-handler req)))
 
    (POST "/command/" req
-         (#'db-api-handlers/command-handler req))))
+     (with-query-checking
+       (#'db-api-handlers/command-handler req)))))

--- a/app/backend/src/clj/teet/user/user_tx.clj
+++ b/app/backend/src/clj/teet/user/user_tx.clj
@@ -26,14 +26,13 @@
         permissions (mapv
                       first
                       (d/q '[:find (pull ?p [:permission/role :db/id])
-                             :in $ ?u ?now
+                             :in $ ?u
                              :where
                              [?u :user/permissions ?p]
                              [(missing? $ ?p :permission/projects)]
                              [(missing? $ ?p :permission/valid-until)]]
                            db
-                           user-id
-                           now))
+                           user-id))
         existing-role (some
                         #(when (= (:permission/role %) role)
                            %)

--- a/app/backend/test/teet/backup/backup_ion_test.clj
+++ b/app/backend/test/teet/backup/backup_ion_test.clj
@@ -53,14 +53,15 @@
         pull-seen-by-manager-tx (fn []
                                   (first
                                    (d/q '[:find (pull ?tx [:db/txInstant :tx/author])
-                                          :in $ ?name ?manager-id
+                                          :in $ ?name ?manager
                                           :where
                                           [?file :file/name ?name]
                                           [?e :file-seen/file ?file]
+                                          [?e :file-seen/user ?manager]
                                           [?e :file-seen/seen-at _ ?tx true]]
                                         (tu/db)
                                         test-file-name
-                                        tu/manager-id)))]
+                                        [:user/id tu/manager-id])))]
     (tu/store-data! :seen-by-manager-at
                     (ffirst (d/q '[:find (max ?d)
                                    :where
@@ -102,7 +103,7 @@
                   [{:file-seen/user {:user/given-name "Danny D."
                                      :user/family-name "Manager"}}]}))
           (is (= (get-in file-with-seen [:file-seen/_file 0 :file-seen/file+user])
-                     [file-id user-id]))))
+                 [file-id user-id]))))
 
       (testing "File seen tx data is correct"
         (let [old-file-seen-tx (tu/get-data :seen-by-manager-tx)

--- a/app/backend/test/teet/test/utils.clj
+++ b/app/backend/test/teet/test/utils.clj
@@ -212,7 +212,9 @@
                                (throw (ex-info "Data fixtures have duplicate tempids!"
                                                {:duplicates duplicates}))
                                (merge current-tempids tempids))))))
-                (f)))
+                (with-redefs [d/q (fn [& args]
+                                    (apply du/q args))]
+                  (f))))
             (finally
               (when-not skip-delete?
                 (log/info "Deleting databases: " test-db-name ", " test-asset-db-name)

--- a/app/common/src/cljc/teet/util/datomic.cljc
+++ b/app/common/src/cljc/teet/util/datomic.cljc
@@ -211,6 +211,7 @@
                            {:got first}))
            (merge {first (take-while (complement keyword?) rest)}
                   (map-by-keywords (drop-while (complement keyword?) rest))))))
+
      (defn- to-map-query
        "Convert multi arg query call to map format"
        [args]
@@ -227,13 +228,19 @@
                (map-by-keywords query))
              {:args args}))
 
+          (and (map? (first args))
+               (contains? (first args) :find))
+          ;; Map query with args
+          (merge {:args (vec (rest args))}
+                 (first args))
+
           (vector? (first args))
           ;; Split by keyword
           (merge {:args (vec (rest args))}
                  (map-by-keywords (first args)))
 
           :else
-          (throw (ex-info "Invalid query call, expected single arg query map or vector as first argument."
+          (throw (ex-info "Invalid query call, expected single arg query map, query map with args or vector as first argument."
                           {:invalid-arguments args})))))
 
      (defn- assert-valid-query [query-args]

--- a/app/common/src/cljc/teet/util/datomic.cljc
+++ b/app/common/src/cljc/teet/util/datomic.cljc
@@ -4,7 +4,8 @@
             [clojure.walk :as walk]
             #?(:clj [datomic.client.api :as d])
             [clojure.set :as set]
-            [teet.util.collection :as cu]))
+            [teet.util.collection :as cu]
+            [clojure.string :as str]))
 
 (s/def :db/ident keyword?)
 (s/def ::enum (s/or :keyword keyword?
@@ -197,3 +198,59 @@
       (vec
        (concat retractions [(assoc changes :db/id id)]))
       [])))
+
+#?(:clj
+   (do
+     (defn- binding-symbols [form]
+       (cu/collect #(and (symbol? %) (str/starts-with? (str %) "?"))
+                   form))
+     (defn- split-by-keywords [[first & rest]]
+       (when first
+         (if-not (keyword? first)
+           (throw (ex-info "Expected keyword"
+                           {:got first}))
+           (concat [[first (take-while (complement keyword?) rest)]]
+                   (split-by-keywords (drop-while (complement keyword?) rest))))))
+     (defn- to-map-query
+       "Convert multi arg query call to map format"
+       [args]
+       (merge
+        {:in '[$]}
+        (cond
+          (and (= 1 (count args))
+               (map? (first args)))
+          ;; Already a map, return it as is
+          (first args)
+
+          (vector? (first args))
+          ;; Split by keyword
+          (into {:args (vec (rest args))}
+                (map (fn [[kw args]]
+                       [kw (vec args)]))
+                (split-by-keywords (first args)))
+
+          :else
+          (throw (ex-info "Invalid query call, expected single arg query map or vector as first argument."
+                          {:invalid-arguments args})))))
+
+     (defn- assert-valid-query [args]
+       (let [{:keys [in args find where] :as q} (to-map-query args)]
+         (when-not (= (count in) (count args))
+           (throw (ex-info ":in list must be same length as args"
+                           {:declared-argument-count (count in)
+                            :received-argument-count (count args)})))
+
+         (let [unreferred-symbols (set/difference
+                                   (binding-symbols in)
+                                   (set/union (binding-symbols find)
+                                              (binding-symbols where)))]
+           (when (seq unreferred-symbols)
+             (throw (ex-info "Unreferred to input binding symbols"
+                             {:unreferred-symbols unreferred-symbols}))))))
+
+     (def datomic-q d/q)
+     (defn q
+       "Wrapper to d/q that asserts some validity rules."
+       [& args]
+       (assert-valid-query args)
+       (apply datomic-q args))))


### PR DESCRIPTION

Basically adds a wrapper to `d/q` that does extra validation against invalid calls to catch bugs easier.
Validates that all input parameters are referred to in the query and that the argument count matches the declared count)