### PR TITLE
TEET-1323 pdf generation fixes

### DIFF
--- a/app/backend/src/clj/teet/util/md.clj
+++ b/app/backend/src/clj/teet/util/md.clj
@@ -136,12 +136,12 @@
 (defmethod md->xsl-fo InlineLinkNode [node]
   (let [text (.getText node)]
     (when-not (str/blank? text)
-      [:fo:block text])))
+      [:fo:block (h/h text)])))
 
 (defmethod md->html InlineLinkNode [node]
   (let [text (.getText node)]
     (when-not (str/blank? text)
-      [:span text])))
+      [:span (h/h text)])))
 
 ;; ignore images (copy pasted)
 (defmethod md->xsl-fo Image [_node] nil)

--- a/app/backend/src/clj/teet/util/md.clj
+++ b/app/backend/src/clj/teet/util/md.clj
@@ -10,7 +10,9 @@
            (com.vladsch.flexmark.ast
              ;; Import node types for rendering
              Paragraph BulletList OrderedList Heading Text
-             StrongEmphasis Emphasis)))
+             StrongEmphasis Emphasis
+
+             InlineLinkNode Image)))
 
 (declare render-md)
 
@@ -33,7 +35,9 @@
 
 (defn- render-children [node]
   (for [c (md-children node)]
-    (md->xsl-fo c)))
+    (do
+      (println "RENDER: " c)
+      (md->xsl-fo c))))
 
 (defn- render-children-html [node]
   (for [c (md-children node)]
@@ -127,6 +131,21 @@
      2 :h4
      3 :h5)
    (render-children-html h)])
+
+(defmethod md->xsl-fo InlineLinkNode [node]
+  (let [text (.getText node)]
+    (when-not (str/blank? text)
+      [:fo:block text])))
+
+(defmethod md->html InlineLinkNode [node]
+  (let [text (.getText node)]
+    (when-not (str/blank? text)
+      [:span text])))
+
+;; ignore images (copy pasted)
+(defmethod md->xsl-fo Image [_node] nil)
+(defmethod md->html Image [_node] nil)
+
 
 (defn create-underline-node [opening-marker text closing-marker]
   (let [state (atom {:opening-marker opening-marker

--- a/app/backend/src/clj/teet/util/md.clj
+++ b/app/backend/src/clj/teet/util/md.clj
@@ -35,9 +35,7 @@
 
 (defn- render-children [node]
   (for [c (md-children node)]
-    (do
-      (println "RENDER: " c)
-      (md->xsl-fo c))))
+    (md->xsl-fo c)))
 
 (defn- render-children-html [node]
   (for [c (md-children node)]

--- a/app/backend/src/clj/teet/util/md.clj
+++ b/app/backend/src/clj/teet/util/md.clj
@@ -12,7 +12,7 @@
              Paragraph BulletList OrderedList Heading Text
              StrongEmphasis Emphasis
 
-             InlineLinkNode Image)))
+             InlineLinkNode LinkRef Image)))
 
 (declare render-md)
 
@@ -92,9 +92,7 @@
    (for [item (md-children ol)]
      [:li (render-children-html item)])])
 
-(defmethod md->xsl-fo Text [t]
-  (str (.getChars t)))
-
+(defmethod md->xsl-fo Text [t] (h/h (str (.getChars t))))
 (defmethod md->html Text [t] (h/h (str (.getChars t))))
 
 (defmethod md->xsl-fo StrongEmphasis [t]
@@ -131,6 +129,9 @@
      2 :h4
      3 :h5)
    (render-children-html h)])
+
+(defmethod md->xsl-fo LinkRef [node] nil)
+(defmethod md->html LinkRef [node] nil)
 
 (defmethod md->xsl-fo InlineLinkNode [node]
   (let [text (.getText node)]


### PR DESCRIPTION
When pasting stuff from HTML to the rich text editor, the content may include stuff that isn't normally creatable with the editor, like links and images.

Add basic support for those and escape text.