### PR TITLE
TEET-1243 part 2: filter incompete attachments in meeting queries

### DIFF
--- a/app/backend/dev-src/user.clj
+++ b/app/backend/dev-src/user.clj
@@ -89,6 +89,14 @@
               {:tx-data [[:db/retract [:user/id user-uuid]
                           :user/permissions permission-eid]]}))
 
+(defn make-file-incomplete!
+  "reverse of local-command :file/upload-complete - for testing incomplete file handling"
+  [file-uuid]
+  (d/transact (environment/datomic-connection)
+              {:tx-data [[:db/retract [:file/id file-uuid]
+                          :file/upload-complete? true]]}))
+
+
 (defn all-comments
   []
   (q '[:find (pull ?e [*])

--- a/app/backend/src/clj/teet/meeting/meeting_db.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_db.clj
@@ -259,10 +259,9 @@
 
 
 (defn without-incomplete-uploads [tree]  
-  (let [filter-attached-to #(some? (:file/upload-complete? %))
-        walker-fn (fn [m]
+  (let [walker-fn (fn [m]
                     (if (not-empty (:file/_attached-to m))
-                      (update m :file/_attached-to #(filterv filter-attached-to %))
+                      (update m :file/_attached-to #(filterv :file/upload-complete? %))
                       m))]
     (walk/postwalk walker-fn tree)))
 
@@ -291,8 +290,8 @@
                                     :meeting.agenda/body
                                     {:meeting.agenda/responsible [:user/family-name :user/given-name :user/id]}
                                     {:meeting.agenda/decisions [:db/id :meeting.decision/body :meeting.decision/number
-                                                                {:file/_attached-to [:file/name :db/id]}]}
-                                    {:file/_attached-to [:file/name :db/id]}]}
+                                                                {:file/_attached-to [:file/name :db/id :file/upload-complete?]}]}
+                                    {:file/_attached-to [:file/name :db/id :file/upload-complete?]}]}
                   {:review/_of [:meta/created-at :review/comment {:review/decision [:db/id :ident]}
                                 {:review/reviewer [:db/id :user/family-name :user/given-name :user/id]}]}
                   {:participation/_in [:participation/role

--- a/app/backend/src/clj/teet/meeting/meeting_db.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_db.clj
@@ -6,6 +6,7 @@
             [teet.meeting.meeting-model :as meeting-model]
             [teet.project.project-db :as project-db]
             [teet.link.link-db :as link-db]
+            [clojure.walk :as walk]
             [teet.meta.meta-query :as meta-query]))
 
 (defn meetings
@@ -256,6 +257,15 @@
       not-empty
       boolean))
 
+
+(defn without-incomplete-uploads [tree]  
+  (let [filter-attached-to #(some? (:file/upload-complete? %))
+        walker-fn (fn [m]
+                    (if (not-empty (:file/_attached-to m))
+                      (update m :file/_attached-to #(filterv filter-attached-to %))
+                      m))]
+    (walk/postwalk walker-fn tree)))
+
 (defn export-meeting
   "Fetch information required for export meeting PDF"
   [db user id]
@@ -266,25 +276,26 @@
     :fetch-links-pred? #(or (contains? % :meeting.agenda/topic)
                             (contains? % :meeting.decision/body))
     :return-links-to-deleted? true}
-   (meta-query/without-deleted
-    db
-    (d/pull db '[:db/id
-                 :meeting/title
-                 :meeting/location
-                 :meeting/start
-                 :meeting/end
-                 :meeting/number
-                 {:activity/_meetings [:db/id {:thk.lifecycle/_activities [{:thk.project/_lifecycles [:thk.project/id]}]}]}
-                 {:meeting/agenda [:db/id
-                                   :meeting.agenda/topic
-                                   :meeting.agenda/body
-                                   {:meeting.agenda/responsible [:user/family-name :user/given-name :user/id]}
-                                   {:meeting.agenda/decisions [:db/id :meeting.decision/body :meeting.decision/number
-                                                               {:file/_attached-to [:file/name :db/id]}]}
-                                   {:file/_attached-to [:file/name :db/id]}]}
-                 {:review/_of [:meta/created-at :review/comment {:review/decision [:db/id :ident]}
-                               {:review/reviewer [:db/id :user/family-name :user/given-name :user/id]}]}
-                 {:participation/_in [:participation/role
-                                      :meta/deleted?
-                                      {:participation/participant [:db/id :user/family-name :user/given-name :user/id]}
-                                      :participation/absent?]}] id))))
+   (without-incomplete-uploads 
+    (meta-query/without-deleted
+     db
+     (d/pull db '[:db/id
+                  :meeting/title
+                  :meeting/location
+                  :meeting/start
+                  :meeting/end
+                  :meeting/number
+                  {:activity/_meetings [:db/id {:thk.lifecycle/_activities [{:thk.project/_lifecycles [:thk.project/id]}]}]}
+                  {:meeting/agenda [:db/id
+                                    :meeting.agenda/topic
+                                    :meeting.agenda/body
+                                    {:meeting.agenda/responsible [:user/family-name :user/given-name :user/id]}
+                                    {:meeting.agenda/decisions [:db/id :meeting.decision/body :meeting.decision/number
+                                                                {:file/_attached-to [:file/name :db/id]}]}
+                                    {:file/_attached-to [:file/name :db/id]}]}
+                  {:review/_of [:meta/created-at :review/comment {:review/decision [:db/id :ident]}
+                                {:review/reviewer [:db/id :user/family-name :user/given-name :user/id]}]}
+                  {:participation/_in [:participation/role
+                                       :meta/deleted?
+                                       {:participation/participant [:db/id :user/family-name :user/given-name :user/id]}
+                                       :participation/absent?]}] id)))))

--- a/app/backend/src/clj/teet/meeting/meeting_pdf.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_pdf.clj
@@ -313,6 +313,8 @@
      {:external-destination url}
      [:fo:inline {:text-decoration "underline" :color "blue"} url]]))
 
+
+;; TBD: incomplete files removal
 (defn meeting-pdf
   ([db user language meeting-id]
    (meeting-pdf db user language meeting-id default-layout-config))

--- a/app/backend/src/clj/teet/meeting/meeting_queries.clj
+++ b/app/backend/src/clj/teet/meeting/meeting_queries.clj
@@ -240,6 +240,46 @@
                    :meta/created-at
                    {:meta/creator [:user/given-name :user/family-name]}]})
 
+(defn fetch-meeting* [db user meeting-id activity-id]
+  (let [meeting
+        (d/pull
+         db
+         `[:db/id
+           :meeting/locked?
+           :meeting/title :meeting/location
+           :meeting/start :meeting/end
+           :meeting/notifications-sent-at
+           :meeting/number :meta/created-at :meta/modified-at
+           {:meeting/organizer ~user-model/user-listing-attributes}
+           {:meeting/agenda [:db/id
+                             :meeting.agenda/topic
+                             :meeting.agenda/body
+                             :meta/created-at :meta/modified-at
+                             {:meeting.agenda/decisions
+                              [:db/id :meeting.decision/body
+                               :meta/created-at :meta/modified-at
+                               :meeting.decision/number
+                               ~attachments]}
+                             {:meeting.agenda/responsible ~user-model/user-listing-attributes}
+                             ~attachments]}
+           {:review/_of [:db/id
+                         :review/comment
+                         :review/decision
+                         :meta/created-at
+                         {:review/reviewer ~user-model/user-listing-attributes}]}
+           {:participation/_in
+            [:db/id
+             :participation/absent?
+             :participation/role
+             :meta/created-at :meta/modified-at
+             {:participation/participant ~user-model/user-listing-attributes}]}]
+         (meeting-db/activity-meeting-id db activity-id meeting-id))]
+    (merge
+     meeting
+     (comment-db/comment-count-of-entity-by-status
+      db user meeting-id :meeting)
+     (entity-db/entity-seen db user meeting-id))))
+
 (defquery :meeting/fetch-meeting
   {:doc "Fetch a single meeting info and project info"
    :context {:keys [db user]}
@@ -260,44 +300,7 @@
                       (meta-query/without-deleted
                        db
                        {:project (fetch-project-meetings db (project-db/activity-project-id db activity-id)) ;; This ends up pulling duplicate information, could be refactored
-                        :meeting (let [meeting
-                                       (d/pull
-                                        db
-                                        `[:db/id
-                                          :meeting/locked?
-                                          :meeting/title :meeting/location
-                                          :meeting/start :meeting/end
-                                          :meeting/notifications-sent-at
-                                          :meeting/number :meta/created-at :meta/modified-at
-                                          {:meeting/organizer ~user-model/user-listing-attributes}
-                                          {:meeting/agenda [:db/id
-                                                            :meeting.agenda/topic
-                                                            :meeting.agenda/body
-                                                            :meta/created-at :meta/modified-at
-                                                            {:meeting.agenda/decisions
-                                                             [:db/id :meeting.decision/body
-                                                              :meta/created-at :meta/modified-at
-                                                              :meeting.decision/number
-                                                              ~attachments]}
-                                                            {:meeting.agenda/responsible ~user-model/user-listing-attributes}
-                                                            ~attachments]}
-                                          {:review/_of [:db/id
-                                                        :review/comment
-                                                        :review/decision
-                                                        :meta/created-at
-                                                        {:review/reviewer ~user-model/user-listing-attributes}]}
-                                          {:participation/_in
-                                           [:db/id
-                                            :participation/absent?
-                                            :participation/role
-                                            :meta/created-at :meta/modified-at
-                                            {:participation/participant ~user-model/user-listing-attributes}]}]
-                                        (meeting-db/activity-meeting-id db activity-id meeting-id))]
-                                   (merge
-                                    meeting
-                                    (comment-db/comment-count-of-entity-by-status
-                                     db user meeting-id :meeting)
-                                    (entity-db/entity-seen db user meeting-id)))}
+                        :meeting (fetch-meeting* db user meeting-id activity-id)}
 
                        (fn [entity]
                          (contains? entity :link/to))))))))


### PR DESCRIPTION
Some pull queries had escaped attention when making the first PR to fix this.

As pull syntax doesn't support testing for absence of attributes, made a walk based filter for removing these as a postprocessing step.

Applied to both PDF generation queries and the regular meeting queries.