### PR TITLE
TEET-1334 fix slow backup

### DIFF
--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -6,7 +6,6 @@
             [teet.integration.integration-context :as integration-context
              :refer [ctx-> defstep]]
             [clojure.java.io :as io]
-            [clojure.pprint :as pprint]
             [teet.util.datomic :as du]
             [teet.log :as log]
             [clojure.string :as str]
@@ -179,7 +178,7 @@
 (defn- output-all-tx [conn out]
   (let [db (d/db conn)
         attr-ident-cache (atom {})
-        out! #(pprint/pprint % out)
+        out! #(binding [*out* out] (prn %))
         ref-attrs (into old-ref-attrs
                         (comp
                          (map first)

--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -197,7 +197,6 @@
                                 (keys tuple-attrs))
         progress! (progress-fn "backup transactions written")]
 
-    (def *c attr-ident-cache)
     (out! {:ref-attrs ref-attrs
            :tuple-attrs tuple-attrs
            :backup-timestamp (java.util.Date.)})


### PR DESCRIPTION
Use `prn` instead of `pprint` as flame graph showed that printing large data structures was a bottleneck.

Also cache `:db/*` idents and only take the `as-of` db when necessary.