### PR TITLE
Update slack.bash

### DIFF
--- a/ci/scripts/slack.bash
+++ b/ci/scripts/slack.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TEET_ENV=`aws ssm get-parameters --names /teet/env --query Parameters[0].Value --output text`
+TEET_ENV=`aws ssm get-parameters --names /teet/base-url --query Parameters[0].Value --output text`
 
 if [ "$CODEBUILD_BUILD_SUCCEEDING" -eq "1" ]
 then


### PR DESCRIPTION
To make a diffeerence between dev and dev2, for example, use the Base URL SSM of env instead of non-uniq teet-env 