### PR TITLE
TEET-1416: authz fix for ext consultants vs cooperation application

### DIFF
--- a/app/backend/resources/authorization.edn
+++ b/app/backend/resources/authorization.edn
@@ -225,8 +225,6 @@
   :manager :full,
   :internal-consultant :link,
   :external-consultant :link},
- :cooperation/application-approval
- {:admin :full, :manager :full, :internal-consultant :full},
  :cost-items/delete-cost-items
  {:admin :full,
   :manager :full,

--- a/app/backend/resources/authorization.edn
+++ b/app/backend/resources/authorization.edn
@@ -51,7 +51,9 @@
  {:admin :full,
   :manager :full,
   :internal-consultant :link,
-  :external-consultant :link},
+  :external-consultant :link,
+  :authenticated-guest :link,
+  :guest :link},
  :maintenance/asset-map
  {:admin :full,
   :manager :full,
@@ -262,7 +264,9 @@
  {:admin :full,
   :manager :full,
   :internal-consultant :link,
-  :external-consultant :link},
+  :external-consultant :link,
+  :authenticated-guest :link,
+  :guest :link},
  :maintenance/asset-filtering
  {:admin :full,
   :manager :full,

--- a/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
+++ b/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
@@ -144,7 +144,7 @@
              application-id :application-id
              response-payload :form-data}
    :project-id (cooperation-db/application-project-id db application-id)
-   :authorization {:cooperation/application-approval {}}
+   :authorization {:cooperation/edit-application {}}
    :pre [(response-id-matches db application-id (:db/id response-payload))]
    :transact
    (db-api-large-text/store-large-text!

--- a/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
+++ b/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
@@ -177,7 +177,7 @@
    :context {:keys [user db]}
    :payload {application-id :application-id}
    :project-id (cooperation-db/application-project-id db application-id)
-   :authorization {:cooperation/application-approval {}}
+   :authorization {:cooperation/edit-application {}}
    :pre [^{:error :application-has-opinion}
          (nil? (:cooperation.application/opinion (du/entity db application-id)))]
    :transact
@@ -209,7 +209,7 @@
    :context {:keys [user db]}
    :payload {:keys [application-id opinion-form]}
    :project-id [:thk.project/id (cooperation-db/application-project-id db application-id)]
-   :authorization {:cooperation/application-approval {}}
+   :authorization {:cooperation/edit-application {}}
    :pre [(opinion-id-matches db application-id (:db/id opinion-form))]
    :transact
    (db-api-large-text/store-large-text!

--- a/app/backend/test/teet/cooperation/cooperation_commands_test.clj
+++ b/app/backend/test/teet/cooperation/cooperation_commands_test.clj
@@ -129,4 +129,27 @@
              Exception
              (tu/local-command :cooperation/delete-application
                                {:thk.project/id project-id
+                                :db/id new-application-id})))))
+
+    
+    (testing "External consultant can add add responses to involved party cooperation applications (bug TEET-1416)"
+      (let [;; Create new application
+            new-application-id (-> (tu/local-command :cooperation/create-application
+                                                     application-payload)
+                                   (get-in [:tempids "new-application"]))]
+        ;; switch user to ext
+        (tu/local-login tu/mock-user-carla-consultant)
+        ;; add response
+        (tu/local-command :cooperation/save-application-response
+                          {:thk.project/id project-id
+                           :application-id new-application-id
+                           :form-data {:cooperation.response/status :cooperation.response.status/no-objection
+                                       :cooperation.response/date (dateu/now)
+                                       :cooperation.response/valid-months 12}})
+
+        ;; Can't be deleted
+        (is (thrown?
+             Exception
+             (tu/local-command :cooperation/delete-application
+                               {:thk.project/id project-id
                                 :db/id new-application-id})))))))

--- a/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
+++ b/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
@@ -1005,7 +1005,7 @@
                                  :entity application})
       :response-uploads-allowed (cooperation-model/application-response-editable? application)
       :save-opinion (authorization-check/authorized?
-                      {:functionality :cooperation/application-approval
+                      {:functionality :cooperation/edit-application
                        :entity application})}
      [:div.cooperation-application-page {:class (<class common-styles/flex-column-1)}
       [cooperation-page-structure


### PR DESCRIPTION
Todo:

- ~~we're saving the :cooperation.response/status field in the save-application command which is equivalent to "approving the application" according to FR314. Need to control this according to the approve-application permission~~.
- application approval is no longer part of the workflow