### PR TITLE
TEET-1478 adds localization for user-has-no-email error

### DIFF
--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -615,6 +615,8 @@
   :bad-request "Bad request",
   :replaced-file-not-latest
   "Can't replace an old version of a file. Replace newest version.",
+  :user-has-no-email
+  "The link can't be emailed. Email address has not been added, please add it through the My account page.",
   :meeting-has-no-decisions
   "The meeting doesn't contain anything to review",
   :email-address-already-in-use "Email address already in use.",

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -610,6 +610,8 @@
   :bad-request "Vigane päring",
   :replaced-file-not-latest
   "Vanemat versiooni ei saa asendada. Asenda uusim versioon.",
+  :user-has-no-email
+  "Viidet ei saa e-postiga saata. Puudub e-posti aadress, palun lisage e-posti aadress minu konto alt.",
   :meeting-has-no-decisions "Koosolekule ei ole otsuseid lisatud",
   :email-address-already-in-use "E-posti aadress on juba kasutusel.",
   :no-participants-with-email
@@ -794,7 +796,7 @@
   :description "Faili kirjeldus",
   :replace-file-confirm "Jah, laen üles uue versiooni",
   :description-required "Faili kirjeldus on puudu",
-  :general-part "Üldine",
+  :general-part "Yldine",
   :select-part-to-upload
   "Valige osa, kuhu üleslaaditud failid lisatakse",
   :file-will-be-added-to-part-text
@@ -907,8 +909,7 @@
    :authority-position
    "Pädeva asutuse põhjendus ja otsus esitatud arvamuse osas",
    :opinion-body "Arvamuse sisu",
-   :no-position-added "Se
-   isukohta pole lisatud",
+   :no-position-added "Seisukohta pole lisatud",
    :title "{opinion-type} maade omanike arvamuste koondtabel",
    :cadastral-id-name "Katastriüksuse tunnus; Katastriüksikuse nimi",
    :units-without-opinions


### PR DESCRIPTION
Adds localization for the case when user tries to send a zip to their email of the tasks files.