### PR TITLE
TEET-1484 Asset location selection on map

### DIFF
--- a/app/backend/nvd-lock.edn
+++ b/app/backend/nvd-lock.edn
@@ -7,6 +7,7 @@
 
   "CVE-2019-17638" ; jetty bytebuffer release (not using jetty to serve requests)
   "CVE-2020-27223" ; Jetty not used to serve requests
+  "CVE-2021-28165" ; jetty high cpu with incorrect tls frame
 
   ;; multiple jackson databind vulnerabilities about classes not being in blocklist
   ;; jackson is included via AWS sdk, but we are not using it to deserialize user provided data

--- a/app/backend/resources/asset-base-schema.edn
+++ b/app/backend/resources/asset-base-schema.edn
@@ -1,168 +1,189 @@
-[{:db/ident :tx/author
-  :db/valueType :db.type/uuid
-  :db/cardinality :db.cardinality/one
-  :db/doc "Id of the user who made this transaction"}
-
- {:db/ident :tx/schema-hash
-  :db/valueType :db.type/string
-  :db/cardinality :db.cardinality/one
-  :db/doc "SHA-256 hash of asset schema file"}
-
- {:db/ident :asset-schema/label
-  :db/valueType :db.type/tuple
-  :db/tupleType :db.type/string
-  :db/cardinality :db.cardinality/one
-  :db/doc "Labels in estonian and english"}
- {:db/ident :asset-schema/description
-  :db/valueType :db.type/tuple
-  :db/tupleType :db.type/string
-  :db/cardinality :db.cardinality/one
-  :db/doc "Description in estonian and english"}
-
- {:db/ident :fclass/fgroup
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one
-  :db/doc "The feature group this feature class belongs to."}
-
- {:db/ident :ctype/parent
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one
-  :db/doc "Ref to feature class or parent ctype this belongs to."}
-
- {:db/ident :enum/attribute
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one
-  :db/doc "Reference to attribute this list item belongs to."}
-
- {:db/ident :asset-schema/unit
-  :db/valueType :db.type/string
-  :db/cardinality :db.cardinality/one
-  :db/doc "SI unit for an attribute"}
-
- {:db/ident :asset-schema/type
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one
-  :db/doc "Schema item type of this entity"}
-
- {:db/ident :asset-schema.type/fgroup :db/doc "Feature group type"}
- {:db/ident :asset-schema.type/fclass :db/doc "Feature class type"}
- {:db/ident :asset-schema.type/ctype :db/doc "Component type"}
- {:db/ident :asset-schema.type/attribute :db/doc "Attribute type"}
- {:db/ident :asset-schema.type/enum :db/doc "Enum (list item) type"}
-
- {:db/ident :attribute/parent
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one
-  :db/doc "The fclass or ctype this attribute belongs to"}
-
- ;; Base attributes of an asset
- {:db/ident :asset/fclass
-  :db/doc "The feature class of this asset."
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one}
-
- {:db/ident :asset/components
-  :db/doc "Components of this asset"
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/many
-  :db/isComponent true}
-
- {:db/ident :component/components
-  :db/doc "Subcomponents of this component"
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/many
-  :db/isComponent true}
-
- {:db/ident :component/ctype
-  :db/doc "The ctype of this component"
-  :db/valueType :db.type/ref
-  :db/cardinality :db.cardinality/one}
-
- {:db/ident :component/inherits-location?
-  :db/doc "Does this component type inherit location from parent?"
-  :db/valueType :db.type/boolean
-  :db/cardinality :db.cardinality/one}
-
- {:db/ident :attribute/min-value
-  :db/doc "The minimum value of an attribute or length for strings."
-  :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one}
- {:db/ident :attribute/max-value
-  :db/doc "The maximum value of an attribute or length for strings."
-  :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one}
-
- {:db/ident :attribute/cost-grouping?
-  :db/doc "Is this attribute part of cost grouping"
-  :db/valueType :db.type/boolean
-  :db/cardinality :db.cardinality/one}
-
- {:db/ident :attribute/mandatory?
-  :db/doc "Is this attribute mandatory when creating cost items"
-  :db/valueType :db.type/boolean
-  :db/cardinality :db.cardinality/one}
-
- ;; PENDING: one asset can be updated in many projects during
- ;; its lifecycle. Should this be a many to many link
- ;; or multi valued...
- ;; probably a new cost item asset is created in all projects
- ;; and the old asset is changed to superseded state and
- ;; the new one will take precedence.
- {:db/ident :asset/project
-  :db/doc "The THK project id this asset is a cost item in"
-  :db/valueType :db.type/string
-  :db/cardinality :db.cardinality/one}
-
- ;; Location of an asset:
- ;; Can be defined as start/end points which can always be
- ;; projected to the road network via Teeregister API.
- ;;
- ;; We also want to store the road address stuff to show it
- ;; and do queries based on it (like: give me assets on road 12122
- ;; between meters 100 to 3000). The road address should be
- ;; saved based on what Teeregister API returns.
-
- {:db/id "loc"
-  :db/ident :ctype/location
-  :db/doc "Special location component. Location is part of any asset or component (that doesn't inherit location). The location is not a subcomponent but the fields are inlined."}
-
- {:db/ident :location/start-point
-  :db/doc "Start point [x y] coordinates."
-  :db/tupleType :db.type/bigdec
-  :db/valueType :db.type/tuple
-  :db/cardinality :db.cardinality/one
-  :attribute/parent "loc"}
-
- {:db/ident :location/end-point
-  :db/doc "End point [x y] coordinates."
-  :db/tupleType :db.type/bigdec
-  :db/valueType :db.type/tuple
-  :db/cardinality :db.cardinality/one
-  :attribute/parent "loc"}
-
- {:db/ident :location/road-nr
-  :db/doc "Road number"
-  :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one
-  :attribute/parent "loc"}
-
- {:db/ident :location/carriageway
-  :db/doc "Carriageway number"
-  :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one
-  :attribute/parent "loc"}
-
- {:db/ident :location/start-m
-  :db/doc "Start meters of the location"
-  :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one
-  :attribute/parent "loc"}
-
- {:db/ident :location/end-m
-  :db/doc "End meters of the location. Omitted for point locations."
-  :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one
-  :attribute/parent "loc"}
+[{:db/ident :asset-schema/initial-base-schema
+  :txes
+  [[{:db/ident :tx/author
+     :db/valueType :db.type/uuid
+     :db/cardinality :db.cardinality/one
+     :db/doc "Id of the user who made this transaction"}
 
 
+    {:db/ident :tx/schema-hash
+     :db/valueType :db.type/string
+     :db/cardinality :db.cardinality/one
+     :db/doc "SHA-256 hash of asset schema file"}
+
+
+    {:db/ident :asset/oid
+     :db/doc "Asset/component OID. Format N40-<FCLASS>-<SEQ#>(-<COMPONENT SEQ#>).
+For example N40-SLD-1 for the first asset in feature class whose OID prefix is SLD."
+     :db/valueType :db.type/string
+     :db/cardinality :db.cardinality/one
+     :db/unique :db.unique/identity}
+
+
+    {:db/ident :fclass/oid-prefix
+     :db/doc "OID prefix for a feature class"
+     :db/valueType :db.type/string
+     :db/cardinality :db.cardinality/one}
+
+    {:db/ident :fclass/oid-sequence-number
+     :db/doc "Last used OID sequence number"
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one
+     :db/noHistory true}
+
+
+    {:db/ident :asset-schema/label
+     :db/valueType :db.type/tuple
+     :db/tupleType :db.type/string
+     :db/cardinality :db.cardinality/one
+     :db/doc "Labels in estonian and english"}
+    {:db/ident :asset-schema/description
+     :db/valueType :db.type/tuple
+     :db/tupleType :db.type/string
+     :db/cardinality :db.cardinality/one
+     :db/doc "Description in estonian and english"}
+
+    {:db/ident :fclass/fgroup
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one
+     :db/doc "The feature group this feature class belongs to."}
+
+    {:db/ident :ctype/parent
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one
+     :db/doc "Ref to feature class or parent ctype this belongs to."}
+
+    {:db/ident :enum/attribute
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one
+     :db/doc "Reference to attribute this list item belongs to."}
+
+    {:db/ident :asset-schema/unit
+     :db/valueType :db.type/string
+     :db/cardinality :db.cardinality/one
+     :db/doc "SI unit for an attribute"}
+
+    {:db/ident :asset-schema/type
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one
+     :db/doc "Schema item type of this entity"}
+
+    {:db/ident :asset-schema.type/fgroup :db/doc "Feature group type"}
+    {:db/ident :asset-schema.type/fclass :db/doc "Feature class type"}
+    {:db/ident :asset-schema.type/ctype :db/doc "Component type"}
+    {:db/ident :asset-schema.type/attribute :db/doc "Attribute type"}
+    {:db/ident :asset-schema.type/enum :db/doc "Enum (list item) type"}
+
+    {:db/ident :attribute/parent
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one
+     :db/doc "The fclass or ctype this attribute belongs to"}
+
+    ;; Base attributes of an asset
+    {:db/ident :asset/fclass
+     :db/doc "The feature class of this asset."
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one}
+
+    {:db/ident :asset/components
+     :db/doc "Components of this asset"
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/many
+     :db/isComponent true}
+
+    {:db/ident :component/components
+     :db/doc "Subcomponents of this component"
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/many
+     :db/isComponent true}
+
+    {:db/ident :component/ctype
+     :db/doc "The ctype of this component"
+     :db/valueType :db.type/ref
+     :db/cardinality :db.cardinality/one}
+
+    {:db/ident :component/inherits-location?
+     :db/doc "Does this component type inherit location from parent?"
+     :db/valueType :db.type/boolean
+     :db/cardinality :db.cardinality/one}
+
+    {:db/ident :attribute/min-value
+     :db/doc "The minimum value of an attribute or length for strings."
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one}
+    {:db/ident :attribute/max-value
+     :db/doc "The maximum value of an attribute or length for strings."
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one}
+
+    {:db/ident :attribute/cost-grouping?
+     :db/doc "Is this attribute part of cost grouping"
+     :db/valueType :db.type/boolean
+     :db/cardinality :db.cardinality/one}
+
+    {:db/ident :attribute/mandatory?
+     :db/doc "Is this attribute mandatory when creating cost items"
+     :db/valueType :db.type/boolean
+     :db/cardinality :db.cardinality/one}
+
+    ;; PENDING: one asset can be updated in many projects during
+    ;; its lifecycle. Should this be a many to many link
+    ;; or multi valued...
+    ;; probably a new cost item asset is created in all projects
+    ;; and the old asset is changed to superseded state and
+    ;; the new one will take precedence.
+    {:db/ident :asset/project
+     :db/doc "The THK project id this asset is a cost item in"
+     :db/valueType :db.type/string
+     :db/cardinality :db.cardinality/one}
+
+    ;; Location of an asset:
+    ;; Can be defined as start/end points which can always be
+    ;; projected to the road network via Teeregister API.
+    ;;
+    ;; We also want to store the road address stuff to show it
+    ;; and do queries based on it (like: give me assets on road 12122
+    ;; between meters 100 to 3000). The road address should be
+    ;; saved based on what Teeregister API returns.
+    {:db/ident :ctype/location
+     :db/doc "Special location component. Location is part of any asset or component (that doesn't inherit location). The location is not a subcomponent but the fields are inlined."}
+    ]
+
+   [{:db/ident :location/start-point
+     :db/doc "Start point [x y] coordinates."
+     :db/tupleType :db.type/bigdec
+     :db/valueType :db.type/tuple
+     :db/cardinality :db.cardinality/one
+     :attribute/parent :ctype/location}
+
+    {:db/ident :location/end-point
+     :db/doc "End point [x y] coordinates."
+     :db/tupleType :db.type/bigdec
+     :db/valueType :db.type/tuple
+     :db/cardinality :db.cardinality/one
+     :attribute/parent :ctype/location}
+
+    {:db/ident :location/road-nr
+     :db/doc "Road number"
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one
+     :attribute/parent :ctype/location}
+
+    {:db/ident :location/carriageway
+     :db/doc "Carriageway number"
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one
+     :attribute/parent :ctype/location}
+
+    {:db/ident :location/start-m
+     :db/doc "Start meters of the location"
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one
+     :attribute/parent :ctype/location}
+
+    {:db/ident :location/end-m
+     :db/doc "End meters of the location. Omitted for point locations."
+     :db/valueType :db.type/long
+     :db/cardinality :db.cardinality/one
+     :attribute/parent :ctype/location}]]}
  ]

--- a/app/backend/resources/asset-base-schema.edn
+++ b/app/backend/resources/asset-base-schema.edn
@@ -121,35 +121,48 @@
  ;; and do queries based on it (like: give me assets on road 12122
  ;; between meters 100 to 3000). The road address should be
  ;; saved based on what Teeregister API returns.
+
+ {:db/id "loc"
+  :db/ident :ctype/location
+  :db/doc "Special location component. Location is part of any asset or component (that doesn't inherit location). The location is not a subcomponent but the fields are inlined."}
+
  {:db/ident :location/start-point
   :db/doc "Start point [x y] coordinates."
   :db/tupleType :db.type/bigdec
   :db/valueType :db.type/tuple
-  :db/cardinality :db.cardinality/one}
+  :db/cardinality :db.cardinality/one
+  :attribute/parent "loc"}
 
  {:db/ident :location/end-point
   :db/doc "End point [x y] coordinates."
   :db/tupleType :db.type/bigdec
   :db/valueType :db.type/tuple
-  :db/cardinality :db.cardinality/one}
+  :db/cardinality :db.cardinality/one
+  :attribute/parent "loc"}
 
  {:db/ident :location/road-nr
   :db/doc "Road number"
   :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one}
+  :db/cardinality :db.cardinality/one
+  :attribute/parent "loc"}
 
  {:db/ident :location/carriageway
   :db/doc "Carriageway number"
   :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one}
+  :db/cardinality :db.cardinality/one
+  :attribute/parent "loc"}
 
  {:db/ident :location/start-m
   :db/doc "Start meters of the location"
   :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one}
+  :db/cardinality :db.cardinality/one
+  :attribute/parent "loc"}
 
  {:db/ident :location/end-m
   :db/doc "End meters of the location. Omitted for point locations."
   :db/valueType :db.type/long
-  :db/cardinality :db.cardinality/one}
+  :db/cardinality :db.cardinality/one
+  :attribute/parent "loc"}
+
+
  ]

--- a/app/backend/resources/asset-base-schema.edn
+++ b/app/backend/resources/asset-base-schema.edn
@@ -112,4 +112,44 @@
   :db/doc "The THK project id this asset is a cost item in"
   :db/valueType :db.type/string
   :db/cardinality :db.cardinality/one}
+
+ ;; Location of an asset:
+ ;; Can be defined as start/end points which can always be
+ ;; projected to the road network via Teeregister API.
+ ;;
+ ;; We also want to store the road address stuff to show it
+ ;; and do queries based on it (like: give me assets on road 12122
+ ;; between meters 100 to 3000). The road address should be
+ ;; saved based on what Teeregister API returns.
+ {:db/ident :location/start-point
+  :db/doc "Start point [x y] coordinates."
+  :db/tupleType :db.type/bigdec
+  :db/valueType :db.type/tuple
+  :db/cardinality :db.cardinality/one}
+
+ {:db/ident :location/end-point
+  :db/doc "End point [x y] coordinates."
+  :db/tupleType :db.type/bigdec
+  :db/valueType :db.type/tuple
+  :db/cardinality :db.cardinality/one}
+
+ {:db/ident :location/road-nr
+  :db/doc "Road number"
+  :db/valueType :db.type/long
+  :db/cardinality :db.cardinality/one}
+
+ {:db/ident :location/carriageway
+  :db/doc "Carriageway number"
+  :db/valueType :db.type/long
+  :db/cardinality :db.cardinality/one}
+
+ {:db/ident :location/start-m
+  :db/doc "Start meters of the location"
+  :db/valueType :db.type/long
+  :db/cardinality :db.cardinality/one}
+
+ {:db/ident :location/end-m
+  :db/doc "End meters of the location. Omitted for point locations."
+  :db/valueType :db.type/long
+  :db/cardinality :db.cardinality/one}
  ]

--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -54,6 +54,7 @@
           (pull-child-ctypes db)))
 
    {:ctype/common (d/pull db ctype-pattern :ctype/common)
+    :ctype/location (d/pull db ctype-pattern :ctype/location)
     :fgroups (mapv first
                    (d/q '[:find (pull ?fg p)
                           :where [?fg :asset-schema/type :asset-schema.type/fgroup]

--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -2,7 +2,8 @@
   (:require [clojure.walk :as walk]
             [datomic.client.api :as d]
             [teet.util.datomic :as du]
-            [teet.util.collection :as cu]))
+            [teet.util.collection :as cu]
+            [clojure.string :as str]))
 
 (def ctype-pattern
   '[*
@@ -115,3 +116,42 @@
       :else
       (throw (ex-info "Expected asset or component"
                       {:unknown-item-id id})))))
+
+(defn next-oid
+  "Get next OID for the given fclass.
+  Returns vector of [update-seq-tx oid] where update-seq-tx is a
+  transaction data map to update the seq# of the fclass and oid
+  is the string oid for the feature."
+  [db fclass]
+  {:pre [(keyword? fclass)]}
+  (let [{:fclass/keys [oid-prefix oid-sequence-number]}
+        (d/pull db [:fclass/oid-prefix :fclass/oid-sequence-number] fclass)]
+    (when-not oid-prefix
+      (throw (ex-info "No OID prefix found for fclass"
+                      {:fclass fclass})))
+    (let [seq-number (inc (or oid-sequence-number 0))]
+      [{:db/ident fclass
+        :fclass/oid-sequence-number seq-number}
+       (str "N40-" oid-prefix "-" seq-number)])))
+
+(defn next-component-oid
+  "Get next OID for a new component in feature."
+  [db feature-oid]
+  {:pre (string? feature-oid)}
+  (str feature-oid "-"
+       (inc
+        (reduce (fn [max-num [component-oid]]
+                  (let [[_ _ _ n] (str/split component-oid #"\-")
+                        num (Long/parseLong n)]
+                    (max max-num num)))
+                0
+                (d/q '[:find ?oid
+                       :where
+                       [_ :asset/oid ?oid]
+                       [(> ?oid ?start)]
+                       [(< ?oid ?end)]
+                       :in $ ?start ?end]
+                     db
+                     ;; Finds all OIDs for this asset
+                     (str feature-oid "-")
+                     (str feature-oid "."))))))

--- a/app/backend/src/clj/teet/asset/asset_queries.clj
+++ b/app/backend/src/clj/teet/asset/asset_queries.clj
@@ -15,16 +15,26 @@
    :args _}
   (asset-db/asset-type-library (environment/asset-db)))
 
+(defn- fetch-cost-item [adb id]
+  (asset-type-library/db->form
+   (asset-type-library/rotl-map
+    (asset-db/asset-type-library adb))
+   (d/pull adb '[*] id)))
+
 (defquery :asset/project-cost-items
   {:doc "Query project cost items"
    :context {:keys [db user] adb :asset-db}
-   :args {project-id :thk.project/id}
+   :args {project-id :thk.project/id
+          cost-item :cost-item}
    :project-id [:thk.project/id project-id]
    ;; fixme: cost items authz
    :authorization {:project/read-info {}}}
-  {:asset-type-library (asset-db/asset-type-library adb)
-   :cost-items (asset-db/project-cost-items adb project-id)
-   :project (project-db/project-by-id db [:thk.project/id project-id])})
+  (merge
+   {:asset-type-library (asset-db/asset-type-library adb)
+    :cost-items (asset-db/project-cost-items adb project-id)
+    :project (project-db/project-by-id db [:thk.project/id project-id])}
+   (when cost-item
+     {:form (fetch-cost-item adb cost-item)})))
 
 (defquery :asset/cost-item
   {:doc "Fetch a single cost item by id"
@@ -32,7 +42,4 @@
    :args {id :db/id}
    :project-id [:thk.project/id (asset-db/cost-item-project adb id)]
    :authorization {:project/read-info {}}}
-  (asset-type-library/db->form
-   (asset-type-library/rotl-map
-    (asset-db/asset-type-library adb))
-   (d/pull adb '[*] id)))
+  (fetch-cost-item adb id))

--- a/app/backend/src/clj/teet/asset/asset_queries.clj
+++ b/app/backend/src/clj/teet/asset/asset_queries.clj
@@ -34,7 +34,7 @@
     :cost-items (asset-db/project-cost-items adb project-id)
     :project (project-db/project-by-id db [:thk.project/id project-id])}
    (when cost-item
-     {:form (fetch-cost-item adb cost-item)})))
+     {:cost-item (fetch-cost-item adb cost-item)})))
 
 (defquery :asset/cost-item
   {:doc "Fetch a single cost item by id"

--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -334,7 +334,7 @@
         (log/error e "TEET backup failed")))))
 
 (defn- migrate [{conn :conn :as ctx}]
-  (environment/migrate conn)
+  (environment/migrate conn @environment/schema)
   ctx)
 
 (defn backup

--- a/app/backend/src/clj/teet/environment.clj
+++ b/app/backend/src/clj/teet/environment.clj
@@ -207,8 +207,7 @@
    (migrate conn schema false))
   ([conn schema force?]
    (try
-     (let [schema @schema
-           applied-migrations (into #{}
+     (let [applied-migrations (into #{}
                                     (map first)
                                     (d/q '[:find ?ident
                                            :where [_ :db/ident ?ident]
@@ -243,9 +242,10 @@
   if the hash of the schema file has changed."
   [conn]
   (try
+    (migrate conn @asset-base-schema)
     (let [schema-source (-> "asset-schema.edn" io/resource slurp)
           hash (sha-256 schema-source)
-          db (migrate conn @asset-base-schema)
+          db (d/db conn)
           last-hash (->>
                      (d/q '[:find ?hash ?txi
                             :where

--- a/app/backend/src/clj/teet/road/road_query_queries.clj
+++ b/app/backend/src/clj/teet/road/road_query_queries.clj
@@ -183,3 +183,21 @@
    :authorization {}}
   (teeregister-api/road-by-geopoint (teeregister-api/create-client client)
                                     distance point))
+
+(defquery :road/line-by-road
+  {:doc "Fetch line geometry based on road address from Teeregister API."
+   :config {client [:road-registry :api]}
+   :args {:keys [road-nr carriageway start-m end-m]}
+   :project-id nil
+   :authorization {}}
+  (teeregister-api/line-by-road (teeregister-api/create-client client)
+                                road-nr carriageway start-m end-m))
+
+(defquery :road/point-by-road
+  {:doc "Fetch point geometry baed on road address from Teeregister API."
+   :config {client [:road-registry :api]}
+   :args {:keys [road-nr carriageway start-m]}
+   :project-id nil
+   :authorization {}}
+  (teeregister-api/point-by-road (teeregister-api/create-client client)
+                                 road-nr carriageway start-m))

--- a/app/backend/src/clj/teet/road/teeregister_api.clj
+++ b/app/backend/src/clj/teet/road/teeregister_api.clj
@@ -71,7 +71,8 @@
    :teeNimi :road-name
    :algus :start-m
    :lopp :end-m
-   :kaugus :distance})
+   :kaugus :distance
+   :maadress :m})
 
 (def ^:private remap-response-keys-xf (map #(set/rename-keys % key-remapping)))
 

--- a/app/backend/test/teet/test/utils.clj
+++ b/app/backend/test/teet/test/utils.clj
@@ -193,7 +193,7 @@
                       *data-fixture-ids* (atom {})]
               (binding [environment/*connection* *connection*]
                 (when migrate?
-                  (environment/migrate *connection*)
+                  (environment/migrate *connection* @environment/schema)
                   (when asset-db?
                     (environment/migrate-asset-db *asset-connection*)))
 

--- a/app/common/src/cljc/teet/asset/asset_type_library.cljc
+++ b/app/common/src/cljc/teet/asset/asset_type_library.cljc
@@ -56,7 +56,9 @@
    (defn coerce-fn [value-type]
      (case value-type
        :db.type/bigdec bigdec
-       :db.type/long #(Long/parseLong %)
+       :db.type/long #(if (string? %)
+                        (Long/parseLong %)
+                        (long %))
        ;; No parsing
        identity)))
 #?(:clj

--- a/app/frontend/resources/routes.edn
+++ b/app/frontend/resources/routes.edn
@@ -167,10 +167,26 @@
 
  :cost-items
  {:path "/projects/:project/cost-items"
-  :parent ::project
+  :parent :project
   :view teet.asset.cost-items-view/cost-items-page
   :state {:query :asset/project-cost-items
+          :args {:thk.project/id project
+                 :cost-item (get query-params :id)}}}
+
+ :new-cost-item
+ {:path "/projects/:project/cost-items/new"
+  :parent :cost-items
+  :view teet.asset.cost-items-view/new-cost-item-page
+  :state {:query :asset/project-cost-items
           :args {:thk.project/id project}}}
+
+ :cost-item
+ {:path "/projects/:project/cost-items/:id(\\d+)"
+  :parent :cost-items
+  :view teet.asset.cost-items-view/cost-item-page
+  :state {:query :asset/project-cost-items
+          :args {:thk.project/id project
+                 :cost-item (->long id)}}}
 
  :unauthorized
  {:path "/unauthorized" :view teet.ui.unauthorized/restricted-path}

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -76,13 +76,15 @@
 (extend-protocol t/Event
 
   SaveCostItem
-  (process-event [_ app]
+  (process-event [_ {page :page :as app}]
     (let [form-data (common-controller/page-state app :form)
           project-id (get-in app [:params :project])
-          fclass (get-in form-data [:feature-group-and-class 1 :db/ident])
+          id (if (= page :new-cost-item)
+               (next-id! "costitem")
+               (:db/id form-data))
           asset (-> form-data
-                    (dissoc :feature-group-and-class :asset/components)
-                    (assoc :asset/fclass fclass))]
+                    (assoc :db/id id)
+                    (dissoc :fgroup :location/geojson))]
       (t/fx app
             {:tuck.effect/type :command!
              :command :asset/save-cost-item

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -5,12 +5,32 @@
             [teet.localization :refer [tr]]
             [teet.util.collection :as cu]
             [teet.log :as log]
-            [teet.routes :as routes]))
+            [teet.routes :as routes]
+            [clojure.string :as str]))
 
 (defonce next-id (atom 0))
 
 (defn- next-id! [prefix]
   (str prefix (swap! next-id inc)))
+
+(def ^:private road-address
+  #(cu/map-vals
+    (fn [x]
+      (when-not (str/blank? x)
+        (common-controller/->long x)))
+    (select-keys % [:location/road-nr :location/carriageway
+                    :location/start-m :location/end-m])))
+
+(defn- point [v]
+  (if (vector? v)
+    ;; already a vector of points
+    v
+    ;; parse "x, y"
+    (let [nums (mapv #(js/parseFloat %) (str/split v #"\s*,\s*"))]
+      (when (and (= (count nums) 2)
+                 (every? #(and (number? %)
+                               (not (js/isNaN %))) nums))
+        nums))))
 
 (defrecord SaveCostItem [form-data])
 (defrecord SaveCostItemResponse [tempid response])
@@ -19,14 +39,20 @@
 (defrecord SaveComponent [parent-id form-data])
 (defrecord SaveComponentResponse [tempid response])
 
-(defrecord SelectLocationOnMap [current-location on-change])
+;;(defrecord SelectLocationOnMap [current-location on-change])
 (defrecord FetchLocation [points result-callback])
-(defrecord FetchLocationResponse [result-callback response])
+;;(defrecord FetchLocationResponse [result-callback response])
 
 (defrecord NewCostItem []) ; start creating new cost item
 (defrecord FetchCostItem [id]) ; fetch cost item for editing
 
 (defrecord UpdateForm [form-data])
+
+;; Response when fetching location based on road address
+(defrecord FetchLocationResponse [address response])
+
+;; Response when fetching road address based on geopoints
+(defrecord FetchRoadResponse [start-end-points response])
 
 (declare process-location-change)
 
@@ -110,15 +136,15 @@
                                      {:component (get-in response [:tempids tempid])})})
                     common-controller/refresh-fx])))
 
-  SelectLocationOnMap
-  (process-event [{:keys [current-location on-change]} app]
+  #_SelectLocationOnMap
+  #_(process-event [{:keys [current-location on-change]} app]
     (common-controller/update-page-state
      app [:select-location]
      (constantly {:current-location current-location
                   :on-change on-change})))
 
-  FetchLocation
-  (process-event [{:keys [points result-callback]} app]
+  #_FetchLocation
+  #_(process-event [{:keys [points result-callback]} app]
     (t/fx app
           (merge
            {:tuck.effect/type :query
@@ -132,8 +158,8 @@
               :args {:point (first points)
                      :distance 100}}))))
 
-  FetchLocationResponse
-  (process-event [{:keys [result-callback response]} app]
+  #_FetchLocationResponse
+  #_(process-event [{:keys [result-callback response]} app]
     (def *r response)
     (let [road (first (sort-by :distance response))
           {:keys [road-nr carriageway start-m end-m geometry]} road
@@ -172,30 +198,139 @@
           {:tuck.effect/type :query
            :query :asset/cost-item
            :args {:db/id (common-controller/->long id)}
-           :result-path (common-controller/page-state-path app :form)})))
+           :result-path (common-controller/page-state-path app :form)}))
+
+
+  ;; When road address was changed on the form, update geometry
+  ;; and start/end points from the fetched response
+  FetchLocationResponse
+  (process-event [{:keys [address response]} app]
+    (if-not (= address (road-address (common-controller/page-state app :form)))
+      (do
+        (log/debug "Stale response for " address " => " response)
+        app)
+
+      (common-controller/update-page-state
+       app [:form]
+       (fn [form]
+         ;; Set start/end points and GeoJSON geometry
+         (if (:location/end-m address)
+           ;; Line geometry
+           (assoc form
+                  :location/start-point (first response)
+                  :location/end-point (last response)
+                  :location/geojson (clj->js
+                                     {:type "FeatureCollection"
+                                      :features [{:type "LineString"
+                                                  :coordinates response}
+                                                 {:type "Point" :coordinates (first response)}
+                                                 {:type "Point" :coordinates (last response)}]}))
+           ;; Point geometry
+           (-> form
+               (assoc :location/start-point response
+                      :location/geojson (clj->js
+                                         {:type "FeatureCollection"
+                                          :features [{:type "Point"
+                                                      :coordinates response}]}))
+               (dissoc :location/end-point)))))))
+
+  FetchRoadResponse
+  (process-event [{:keys [start-end-points response]} app]
+    (if-not (= start-end-points
+               (select-keys (common-controller/page-state app :form)
+                            [:location/start-point :location/end-point]))
+      (do
+        (log/debug "Stale response for " start-end-points " => " response)
+        app)
+
+      (common-controller/update-page-state
+       app [:form]
+       (fn [form]
+         (let [{:keys [geometry road-nr carriageway start-m end-m m]}
+               (first (sort-by :distance response))]
+           (when geometry
+             (let [geojson (js/JSON.parse geometry)
+                   start (when end-m (aget geojson "coordinates" 0))
+                   end (when end-m (last (aget geojson "coordinates")))]
+               (assoc form
+                      :location/geojson
+                      #js {:type "FeatureCollection"
+                           :features
+                           (if end-m
+                             #js [geojson
+                                  #js {:type "Point" :coordinates start}
+                                  #js {:type "Point" :coordinates end}]
+                             #js [geojson])}
+                      :location/road-nr road-nr
+                      :location/carriageway carriageway
+                      :location/start-m (or m start-m)
+                      :location/end-m end-m
+                      :foo response))))))
+      )))
 
 (defn- process-location-change
   "Check if location fields have been edited and need to retrigger
   Teeregister API calls."
   [app old-form new-form]
-  (let [start-end-points #(select-keys % [:location/start-point :location/end-point])
-        road-address #(select-keys % [:location/road-nr :location/carriageway
-                                      :location/start-m :location/end-m])]
+  (let [start-end-points #(select-keys % [:location/start-point :location/end-point])]
 
     (cond
       ;; Manually edited start/end points, refetch road section
       (not= (start-end-points old-form)
             (start-end-points new-form))
-      (do
-        (println "muutettu pisteitä")
-        app)
+      (let [start (point (:location/start-point new-form))
+            end (point (:location/end-point new-form))]
+        (log/debug "start: " start ", end: " end)
+        (cond
+          ;; 2 geopoints specified
+          (and start end)
+          (t/fx app
+                {:tuck.effect/type :query
+                 :query :road/by-2-geopoints
+                 :args {:distance 100 :start start :end end}
+                 :result-event (partial ->FetchRoadResponse (start-end-points new-form))})
 
-      ;; Manually edited road location, refetch points
+          start
+          (t/fx app
+                {:tuck.effect/type :query
+                 :query :road/by-geopoint
+                 :args {:distance 100 :point start}
+                 :result-event (partial ->FetchRoadResponse (start-end-points new-form))})
+
+
+          ;; No valid points, don't fetch anything and remove road address
+          :else
+          (dissoc app :location/road-nr :location/carriageway :location/start-m :location/end-m)))
+
+      ;; Manually edited road location, refetch geometry and points
       (not= (road-address old-form)
             (road-address new-form))
-      (do
-        (println "muutettu tieosoitetta")
-        app)
+      (let [{:location/keys [road-nr carriageway start-m end-m]} (road-address new-form)]
+        (cond
+          ;; All values present, fetch line geometry
+          (and road-nr carriageway start-m end-m)
+          (t/fx app
+                {:tuck.effect/type :query
+                 :query :road/line-by-road
+                 :args {:road-nr road-nr
+                        :carriageway carriageway
+                        :start-m start-m
+                        :end-m end-m}
+                 :result-event (partial ->FetchLocationResponse (road-address new-form))})
+
+          ;; Valid start point, fetch a point geometry
+          (and road-nr carriageway start-m)
+          (t/fx app
+                {:tuck.effect/type :query
+                 :query :road/point-by-road
+                 :args {:road-nr road-nr
+                        :carriageway carriageway
+                        :start-m start-m}
+                 :result-event (partial ->FetchLocationResponse (road-address new-form))})
+
+          ;; No valid road address
+          :else
+          (common-controller/update-page-state app [:form] dissoc :geojson)))
 
       :else
       app)))

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -45,7 +45,6 @@
 (defrecord SaveCostItem [])
 (defrecord SaveCostItemResponse [tempid response])
 (defrecord DeleteComponent [id])
-(defrecord DeleteComponentResponse [fetched-cost-item-atom id response])
 (defrecord SaveComponent [component-id])
 (defrecord SaveComponentResponse [tempid response])
 
@@ -171,17 +170,7 @@
              :command :asset/delete-component
              :payload {:db/id id
                        :project-id project-id}
-             :result-event (partial ->DeleteComponentResponse fetched-cost-item-atom id)})))
-
-  DeleteComponentResponse
-  (process-event [{:keys [fetched-cost-item-atom id]} app]
-    (swap! fetched-cost-item-atom
-           (fn [cost-item]
-             (cu/without #(and (map? %) (= id (:db/id %))) cost-item)))
-    (snackbar-controller/open-snack-bar
-     app
-     (tr [:asset :cost-item-component-deleted])))
-
+             :result-event common-controller/->Refresh})))
 
   SaveComponent
   (process-event [_ app]

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -203,10 +203,9 @@
            (remove nil?
                    [(when (string? tempid)
                       {:tuck.effect/type :navigate
-                       :page :cost-items
-                       :params (merge (:params app)
-                                      {:component (get-in response [:tempids tempid])})
-                       :query {}})
+                       :page :cost-item
+                       :params (:params app)
+                       :query {:component (get-in response [:tempids tempid])}})
                     common-controller/refresh-fx])))
 
   UpdateForm

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -264,9 +264,7 @@
                       :location/road-nr road-nr
                       :location/carriageway carriageway
                       :location/start-m (or m start-m)
-                      :location/end-m end-m
-                      :foo response))))))
-      )))
+                      :location/end-m end-m)))))))))
 
 (defn- process-location-change
   "Check if location fields have been edited and need to retrigger

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -8,7 +8,7 @@
             [teet.ui.form :as form]
             [teet.ui.select :as select]
             [teet.asset.asset-library-view :as asset-library-view :refer [tr*]]
-            [teet.ui.material-ui :refer [Grid Link]]
+            [teet.ui.material-ui :refer [Grid Link CircularProgress]]
             [teet.ui.text-field :as text-field]
             [clojure.string :as str]
             [teet.util.string :as string]
@@ -453,7 +453,7 @@
              [label-for p])
            (repeat " / "))))])
 
-(defn- component-form [e! atl component-id cost-item-data]
+(defn- component-form* [e! atl component-id cost-item-data]
   (r/with-let [initial-component-data
                (last (cost-items-controller/find-component-path cost-item-data
                                                                 component-id))
@@ -497,6 +497,15 @@
            (when (seq allowed-components)
              [add-component-menu allowed-components
               (e! cost-items-controller/->AddComponent)])))])))
+
+(defn component-form
+  [e! atl component-id cost-item-data]
+  ;; Delay mounting of component form until it is in app state.
+  ;; This is needed when creating a new component and navigating to it
+  ;; after save, as refresh fetch will happen after navigation.
+  (if (nil? (cost-items-controller/find-component-path cost-item-data component-id))
+    [CircularProgress]
+    [component-form* e! atl component-id cost-item-data]))
 
 (defn- cost-item-hierarchy
   "Show hierarchy of existing cost items, grouped by fgroup and fclass."
@@ -570,10 +579,3 @@
 
        ^{:key (str (:db/id cost-item))}
        [cost-item-form e! asset-type-library cost-item])]))
-
-(defn cost-item-component-page
-  [e! {params :params :as app} {:keys [asset-type-library cost-item] :as state}]
-  (let [{:keys [component]} params]
-    [cost-items-page-structure
-     e! app state
-     [component-form e! asset-type-library component cost-item]]))

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -105,15 +105,23 @@
    [buttons/button-text {:on-click (e! cost-items-controller/->SelectLocationOnMap
                                        value on-change)}
     "open map"]
-   (pr-str value)])
+   #_(pr-str value)])
 
 (defn- location-entry [{:keys [e! on-change value] :as attr-opts}]
   [:<>
    [attribute-grid-item
-    [form/field {:attribute [:location/start :location/end
+    [form/field {:attribute [:location/start-point :location/end-point
                              :location/road-nr :location/carriageway
                              :location/start-m :location/end-m]}
      [location-map-control {:e! e!}]]]
+
+   [attribute-grid-item
+    [form/field :location/start-point
+     [text-field/TextField {}]]]
+
+   [attribute-grid-item
+    [form/field :location/end-point
+     [text-field/TextField {}]]]
 
    [attribute-grid-item
     [form/field :location/road-nr

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -417,11 +417,11 @@
 
         [form/footer2]]
 
-       ;; Components
+       ;; Components (show only for existing)
        (when initial-data
          [:<>
           [components-tree {:e! e!
-                            :asset initial-data
+                            :asset form-data
                             :allowed-components (:ctype/_parent feature-class)}]
 
           [add-component-menu

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -132,9 +132,16 @@
       (reset! current-value value)
       [map-view/map-view e!
        {:on-click (fn [{c :coordinate}]
-                    (on-change (assoc @current-value
-                                      (if (swap! start-point not)
-                                        0 1) c)))
+                    (let [[start end :as v] @current-value]
+                      (cond
+                        ;; If no start point, set it
+                        (nil? start) (on-change (assoc v 0 c))
+
+                        ;; If no end point, set it
+                        (nil? end) (on-change (assoc v 1 c))
+
+                        ;; Otherwise do nothing
+                        :else nil)))
         :event-handlers (drag/drag-feature
                          (comp :map/feature :geometry)
                          drag/on-drag-set-coordinates

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -126,7 +126,7 @@
 (defn- location-map [{:keys [e! value on-change]}]
   (r/with-let [state (r/atom {:points [nil nil] :point 0})]
     ;;(project-map-view/create-project-map e! app project)
-    (let [[start end _road-nr _carriageway _start-m _end-m geojson] value]
+    (let [[_start _end _road-nr _carriageway _start-m _end-m geojson] value]
       [map-view/map-view e!
        {:on-click (fn [{c :coordinate}]
                     (let [points
@@ -143,14 +143,7 @@
                  (when-let [g geojson]
                    (map-layers/geojson-data-layer
                     "selected-road-geometry"
-                    #js {:type "FeatureCollection"
-                         :features (if (= "LineString" (aget g "type"))
-                                     ;; Add start/end when linestring
-                                     #js [g
-                                          #js {:type "Point" :coordinates start}
-                                          #js {:type "Point" :coordinates end}]
-                                     ;; Single point
-                                     #js [g])}
+                    geojson
                     map-features/asset-road-line-style
                     {:fit-on-load? true}))}}])))
 

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -31,6 +31,7 @@
             [teet.theme.theme-colors :as theme-colors]
             [teet.project.project-map-view :as project-map-view]
             [teet.map.openlayers :as openlayers]
+            [teet.map.openlayers.drag :as drag]
             [teet.log :as log]
             [teet.map.map-view :as map-view]
             [teet.map.map-layers :as map-layers]
@@ -134,13 +135,25 @@
                     (on-change (assoc @current-value
                                       (if (swap! start-point not)
                                         0 1) c)))
+        :event-handlers (drag/drag-feature
+                         (comp :map/feature :geometry)
+                         drag/on-drag-set-coordinates
+                         (fn [target to]
+                           (when-let [p (some-> target :geometry :map/feature
+                                                .getProperties (aget "start/end"))]
+                             (on-change
+                              (assoc @current-value
+                                     (case p
+                                       "start" 0
+                                       "end" 1)
+                                     to)))))
         :layers {:selected-road-geometry
                  (when-let [g geojson]
                    (map-layers/geojson-data-layer
                     "selected-road-geometry"
                     geojson
                     map-features/asset-road-line-style
-                    {:fit-on-load? true}))}}])))
+                    {:fit-on-load? false #_true}))}}])))
 
 (defn- attributes* [e! attrs inherits-location? rotl]
   (r/with-let [open? (r/atom #{:location :cost-grouping :common :details})

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -124,21 +124,16 @@
      [text-field/TextField {:type :number}]]]])
 
 (defn- location-map [{:keys [e! value on-change]}]
-  (r/with-let [state (r/atom {:points [nil nil] :point 0})]
+  (r/with-let [start-point (atom false)
+               current-value (atom value)]
     ;;(project-map-view/create-project-map e! app project)
-    (let [[_start _end _road-nr _carriageway _start-m _end-m geojson] value]
+    (let [geojson (last value)]
+      (reset! current-value value)
       [map-view/map-view e!
        {:on-click (fn [{c :coordinate}]
-                    (let [points
-                          (-> state
-                              (swap! (fn [{:keys [points point] :as state}]
-                                       (merge state
-                                              {:points (assoc points point c)
-                                               :point (if (zero? point) 1 0)})))
-                              :points)]
-                      (e! (cost-items-controller/->FetchLocation
-                           (remove nil? points)
-                           on-change))))
+                    (on-change (assoc @current-value
+                                      (if (swap! start-point not)
+                                        0 1) c)))
         :layers {:selected-road-geometry
                  (when-let [g geojson]
                    (map-layers/geojson-data-layer

--- a/app/frontend/src/cljs/teet/common/common_controller.cljs
+++ b/app/frontend/src/cljs/teet/common/common_controller.cljs
@@ -525,11 +525,21 @@
              (fn [page-state]
                (apply update-fn page-state args))))
 
+(defn assoc-page-state
+  "Assoc value to current page state."
+  [{page :page :as app} path value]
+  (assoc-in app (into [:route page] path) value))
+
 (defn page-state
   "Get the state of the current page.
   If path components are given, takes that path from page-state."
   [{page :page :as app} & path]
   (get-in app (into [:route page] path)))
+
+(defn page-state-path
+  "Return path in app state for the page state."
+  [{page :page} & path]
+  (into [:route page] path))
 
 (defn feature-enabled? [feature]
   {:pre [(keyword? feature)]}

--- a/app/frontend/src/cljs/teet/map/map_features.cljs
+++ b/app/frontend/src/cljs/teet/map/map_features.cljs
@@ -84,6 +84,15 @@
                                                               :opacity 0.5})
                                :zIndex 3})]))
 
+(defn asset-road-line-style [^ol.render.Feature feature res]
+  (case (-> feature .getGeometry .getType)
+    "Point" (ol.style.Style.
+             #js {:image (ol.style.Circle.
+                          #js {:fill (ol.style.Fill. #js {:color "#ff30aa"})
+                               :stroke (ol.style.Stroke. #js {:color "#ffffff"})
+                               :radius 20})})
+    "LineString" (project-line-style feature res)))
+
 (def electric-pattern
   (let [a (atom nil)
         canvas (.createElement js/document "canvas")]

--- a/app/frontend/src/cljs/teet/map/map_features.cljs
+++ b/app/frontend/src/cljs/teet/map/map_features.cljs
@@ -86,11 +86,15 @@
 
 (defn asset-road-line-style [^ol.render.Feature feature res]
   (case (-> feature .getGeometry .getType)
-    "Point" (ol.style.Style.
-             #js {:image (ol.style.Circle.
-                          #js {:fill (ol.style.Fill. #js {:color "#ff30aa"})
-                               :stroke (ol.style.Stroke. #js {:color "#ffffff"})
-                               :radius 20})})
+    "Point" #js [(ol.style.Style.
+                  #js {:image (ol.style.Circle.
+                               #js {:fill (ol.style.Fill. #js {:color "black"})
+                                    :radius 2})})
+                 (ol.style.Style.
+                  #js {:image (ol.style.Circle.
+                               #js {:stroke (ol.style.Stroke. #js {:color "black"})
+                                    :fill (ol.style.Fill. #js {:color "rgba(0,0,0,0.5)"})
+                                    :radius 10})})]
     "LineString" (project-line-style feature res)))
 
 (def electric-pattern

--- a/app/frontend/src/cljs/teet/map/map_layers.cljs
+++ b/app/frontend/src/cljs/teet/map/map_layers.cljs
@@ -77,12 +77,15 @@
                          (fit-extent fit-padding layer)))
                      on-select))
 
-(defn geojson-data-layer [name geojson style-fn  {:keys [min-resolution max-resolution
-                                                         z-index opacity fit-on-load?
-                                                         fit-padding on-select on-load]
-                                                  :or {z-index 99
-                                                       opacity 1
-                                                       fit-padding [0 0 0 0]}}]
+(defn geojson-data-layer [name geojson style-fn
+                          {:keys [min-resolution max-resolution
+                                  z-index opacity
+                                  fit-on-load? fit-condition
+                                  fit-padding on-select on-load]
+                           :or {z-index 99
+                                opacity 1
+                                fit-padding [0 0 0 0]
+                                fit-condition (constantly true)}}]
   (geojson/->GeoJSON name
                      default-projection
                      nil
@@ -95,7 +98,7 @@
                      (fn [layer]
                        (when on-load
                          (on-load layer))
-                       (when fit-on-load?
+                       (when (and fit-on-load? (fit-condition layer))
                          (fit-extent fit-padding layer)))
                      on-select))
 

--- a/app/frontend/src/cljs/teet/map/map_view.cljs
+++ b/app/frontend/src/cljs/teet/map/map_view.cljs
@@ -350,11 +350,7 @@
          :class class
          :extent (or extent default-extent)
          :center default-center
-         ;:selection          nav/valittu-hallintayksikko
-         :on-drag (fn [_item _event]
-                    #_(log/debug "drag" item event)
-                    #_(paivita-extent item event)
-                    #_(t/julkaise! {:aihe :karttaa-vedetty}))
+         :event-handlers (:event-handlers opts)
          :on-postrender (fn [e]
                           (let [old-z @current-zoom
                                 new-z (some->> e openlayers/event-map openlayers/map-zoom js/Math.round)

--- a/app/frontend/src/cljs/teet/map/openlayers.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers.cljs
@@ -231,11 +231,13 @@
   [this e]
   (let [c (.-coordinate e)
         type (.-type e)]
-    {:type     (case type
+    {:event e
+     :type     (case type
                  "pointermove" :hover
                  "click" :click
                  "singleclick" :click
-                 "dblclick" :dbl-click)
+                 "dblclick" :dbl-click
+                 (keyword type))
      :geometry (event-geometry this e)
      :location [(aget c 0) (aget c 1)]
      :x        (aget (.-pixel e) 0)
@@ -546,7 +548,9 @@
     (set-drag-handler this ol3 (:on-drag mapspec))
     (set-zoom-handler this ol3 (:on-zoom mapspec))
     (set-postrender-handler this ol3 (:on-postrender mapspec))
-
+    (doseq [[event handler] (:event-handlers mapspec)]
+      (.on ol3 event (fn [e]
+                       (handler (event-description this e)))))
     (update-ol3-geometries this (:geometries mapspec))
     (update-ol3-overlays this (:overlays mapspec))
 

--- a/app/frontend/src/cljs/teet/map/openlayers/drag.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers/drag.cljs
@@ -1,0 +1,29 @@
+(ns teet.map.openlayers.drag
+  "Drag event handling")
+
+(defn drag-feature [accept on-drag on-drop]
+  (let [drag-target (atom nil)]
+    {"pointerdown"
+     (fn [e]
+       (when (accept e)
+         (reset! drag-target e)))
+
+     "pointerdrag"
+     (fn [e]
+       (when-let [target @drag-target]
+         (.preventDefault (:event e))
+         (on-drag target e)))
+
+     "pointerup"
+     (fn [e]
+       (when-let [target @drag-target]
+         (reset! drag-target nil)
+         (on-drop target (:location e))))}))
+
+(defn on-drag-set-coordinates
+  "On-drag callback that sets coordinates to dragged position."
+  [target e]
+  (let [f (-> target :geometry :map/feature)]
+    (-> f
+        .getGeometry
+        (.setCoordinates (clj->js (:location e))))))

--- a/app/frontend/src/cljs/teet/map/openlayers/drag.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers/drag.cljs
@@ -1,11 +1,13 @@
 (ns teet.map.openlayers.drag
   "Drag event handling")
 
-(defn drag-feature [accept on-drag on-drop]
+(defn drag-feature [{:keys [accept on-drag on-drop
+                            dragging?]}]
   (let [drag-target (atom nil)]
     {"pointerdown"
      (fn [e]
        (when (accept e)
+         (when dragging? (reset! dragging? true))
          (reset! drag-target e)))
 
      "pointerdrag"
@@ -17,6 +19,7 @@
      "pointerup"
      (fn [e]
        (when-let [target @drag-target]
+         (when dragging? (reset! dragging? false))
          (reset! drag-target nil)
          (on-drop target (:location e))))}))
 

--- a/app/frontend/src/cljs/teet/map/openlayers/geojson.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers/geojson.cljs
@@ -82,14 +82,16 @@
 
           ol-layer (or ol-layer
                        (ol.layer.Vector.
-                        #js {:source source
+                        #js {:updateWhileInteracting true
+                             :source source
                              :wrapX true}))]
 
 
       (.setStyle ol-layer style-fn)
 
       (when on-change
-        (.on source "change" #(on-change {:extent (.getExtent source)
+        (.on source "change" #(on-change {:layer ol-layer
+                                          :extent (.getExtent source)
                                           :source source})))
 
       (when on-select


### PR DESCRIPTION
Add selection of location for asset by clicking on map

One click takes a point geometry and second click turns it into a line geometry.

Fills in road address values (road, carriageway, start, end) and shows the geometry on the map.