### PR TITLE
TEET-1357 and TEET-1358 fixes

### DIFF
--- a/app/frontend/src/cljs/teet/land/owner_opinion_controller.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_controller.cljs
@@ -6,6 +6,7 @@
 (defrecord OpinionFormClose [])
 (defrecord OpinionFormOpen [])
 (defrecord IncreaseCommentCount [land-unit-id])
+(defrecord DecreaseCommentCount [land-unit-id])
 
 (extend-protocol t/Event
   SubmitOpinionForm
@@ -21,6 +22,10 @@
   IncreaseCommentCount
   (process-event [{:keys [land-unit-id]} app]
     (update-in app [:route :project :land-owner-comment-count land-unit-id] inc))
+
+  DecreaseCommentCount
+  (process-event [{:keys [land-unit-id]} app]
+    (update-in app [:route :project :land-owner-comment-count land-unit-id] dec))
 
   OpinionFormOpen
   (process-event [_ app]

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -273,6 +273,7 @@
    (doall
      (for [[label data is-bold is-label-hidden :as row] data
            :when row]
+       ^{:key (str data "-" label)}
        [:div
         {:class [(<class common/info-row-item-style false)]}
         (if (true? is-label-hidden)

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -286,7 +286,7 @@
   [opinion-list-header-row
    [[(:land-owner-opinion/respondent-name opinion) (get-activity-name opinion) true false]
     ["." "/" false true]
-    (if (nil? (:land-owner-opinion/respondent-connection-to-land opinion))
+    (if (clojure.string/blank? (:land-owner-opinion/respondent-connection-to-land opinion))
       ["." (get-activity-type opinion) false true]
       [(:land-owner-opinion/respondent-connection-to-land opinion) (get-activity-type opinion) false false])]])
 

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -266,10 +266,29 @@
   (let [activity-type (get-in opinion [:land-owner-opinion/type])]
     (tr-enum activity-type)))
 
+(defn opinion-list-header-row
+  "[[data-title data-value is-bold is-label-hidden]...]"
+  [data]
+  [:div {:class (<class common-styles/flex-row-wrap)}
+   (doall
+     (for [[label data is-bold is-label-hidden :as row] data
+           :when row]
+       [:div
+        {:class [(<class common/info-row-item-style false)]}
+        (if (true? is-label-hidden)
+          [typography/HiddenText label]
+          (if (true? is-bold)
+            [typography/SectionHeading label]
+            [typography/Text label]))
+        [:div data]]))])
+
 (defn owner-opinion-heading [opinion]
-  [common/basic-information-row
-   [[(:land-owner-opinion/respondent-name opinion) (get-activity-name opinion)]
-    [(:land-owner-opinion/respondent-connection-to-land opinion) (get-activity-type opinion)]]])
+  [opinion-list-header-row
+   [[(:land-owner-opinion/respondent-name opinion) (get-activity-name opinion) true false]
+    ["." "/" false true]
+    (if (nil? (:land-owner-opinion/respondent-connection-to-land opinion))
+      ["." (get-activity-type opinion) false true]
+      [(:land-owner-opinion/respondent-connection-to-land opinion) (get-activity-type opinion) false false])]])
 
 (defn owner-opinion-edit-form [e! form-state close-form-and-refresh project target close-event]
   (r/with-let [form-change (form/update-atom-event form-state merge)

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -276,9 +276,9 @@
   [data]
   [:div {:class (<class common-styles/flex-row-wrap)}
    (doall
-     (for [[label data is-bold is-label-hidden :as row] data
+     (for [{:keys [label item is-bold is-label-hidden] :as row} data
            :when row]
-       ^{:key (str data "-" label)}
+       ^{:key (str item "-" label)}
        [:div
         {:class [(<class row-item-style)]}
         (if (true? is-label-hidden)
@@ -286,15 +286,27 @@
           (if (true? is-bold)
             [typography/SectionHeading label]
             [typography/Text label]))
-        [:div data]]))])
+        [:div item]]))])
 
 (defn owner-opinion-heading [opinion]
   [opinion-list-header-row
-   [[(:land-owner-opinion/respondent-name opinion) (get-activity-name opinion) true false]
-    ["." "/" false true]
+   [{:label (:land-owner-opinion/respondent-name opinion)
+     :item (get-activity-name opinion)
+     :is-bold true
+     :is-label-hidden false}
+    {:label "."
+     :item "/"
+     :is-bold false
+     :is-label-hidden true}
     (if (clojure.string/blank? (:land-owner-opinion/respondent-connection-to-land opinion))
-      ["." (get-activity-type opinion) false true]
-      [(:land-owner-opinion/respondent-connection-to-land opinion) (get-activity-type opinion) false false])]])
+      {:label "."
+       :item (get-activity-type opinion)
+       :is-bold false
+       :is-label-hidden true}
+      {:label (:land-owner-opinion/respondent-connection-to-land opinion)
+       :item (get-activity-type opinion)
+       :is-bold false
+       :is-label-hidden false})]])
 
 (defn owner-opinion-edit-form [e! form-state close-form-and-refresh project target close-event]
   (r/with-let [form-change (form/update-atom-event form-state merge)

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -293,7 +293,11 @@
 
 (defn owner-opinion-edit-form [e! form-state close-form-and-refresh project target close-event]
   (r/with-let [form-change (form/update-atom-event form-state merge)
-               activities (get-activities project)]
+               activities (get-activities project)
+               decrease-opinions-count (fn [_response]
+                                         (fn [e!]
+                                           (e! (opinion-controller/->DecreaseCommentCount target))
+                                           (close-form-and-refresh)))]
     [:<>
      [form/form2 {:e! e!
                   :on-change-event form-change
@@ -310,7 +314,7 @@
                   :delete (common-controller/->SaveFormWithConfirmation
                             :land-owner-opinion/delete-opinion
                             {:db/id (:db/id @form-state)}
-                            close-form-and-refresh
+                            decrease-opinions-count
                             (tr [:land-owner-opinion :delete :success-message]))
                   :delete-message (tr [:land-owner-opinion :delete :confirmation-text])
                   :delete-cancel-button-text (tr [:land-owner-opinion :delete :cancel-text])

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -266,6 +266,11 @@
   (let [activity-type (get-in opinion [:land-owner-opinion/type])]
     (tr-enum activity-type)))
 
+(defn row-item-style
+  []
+  {:margin-right "0.5rem"
+   :margin-bottom "1rem"})
+
 (defn opinion-list-header-row
   "[[data-title data-value is-bold is-label-hidden]...]"
   [data]
@@ -275,7 +280,7 @@
            :when row]
        ^{:key (str data "-" label)}
        [:div
-        {:class [(<class common/info-row-item-style false)]}
+        {:class [(<class row-item-style)]}
         (if (true? is-label-hidden)
           [typography/HiddenText label]
           (if (true? is-bold)

--- a/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
+++ b/app/frontend/src/cljs/teet/land/owner_opinion_view.cljs
@@ -224,7 +224,7 @@
                             :border-bottom-color theme-colors/border-dark}}}
   {:border-top "1px solid"
    :border-color theme-colors/border-dark
-   :padding "1rem"})
+   :padding "1rem 1rem 1rem 0"})
 
 (defn opinion-view-container
   [{:keys [content text-color open? heading heading-button on-toggle-open edit-atom]} bg-color]

--- a/app/frontend/src/cljs/teet/ui/typography.cljs
+++ b/app/frontend/src/cljs/teet/ui/typography.cljs
@@ -46,6 +46,9 @@
    :line-height    1.375
    :letter-spacing "0.25px"})
 
+(defn- hidden-text-style []
+  {:visibility :hidden})
+
 (defn- data-label-style []
   {:fontFamily    "Roboto Condensed"
    :fontWeight    400
@@ -75,6 +78,7 @@
 (def Subtitle2 (util/make-component :p {:class "subtitle2"}))
 
 (def Text (util/make-component :p {}))
+(def HiddenText (util/make-component :p {:class (<class hidden-text-style)}))
 (def TextBold (util/make-component :p {:class "body1-bold"}))
 (def Text2 (util/make-component :p {:class "body2"}))
 (def Text2Bold (util/make-component :p {:class "body2-bold"}))


### PR DESCRIPTION
- opinion author relationship with land is not in bold style as designed
- if the relationship empty the layout is still the same (place is taken even if empty)
- opinions list rows aligned to the left as designed
- update opinions count after delete