### PR TITLE
Fix fetching of xroad cache results

### DIFF
--- a/app/backend/src/clj/teet/integration/x_road/property_registry.clj
+++ b/app/backend/src/clj/teet/integration/x_road/property_registry.clj
@@ -253,6 +253,7 @@
                                               #{:payload}
                                               {:id estate-id})
                             first
+                            :payload
                             x-road/string->zipped-xml
                             kinnistu-d-parse-response)]
     (merge (:payload estate)

--- a/app/backend/src/clj/teet/integration/x_road/property_registry.clj
+++ b/app/backend/src/clj/teet/integration/x_road/property_registry.clj
@@ -289,7 +289,7 @@
         missing (set/difference (set estate-ids) (set (keys estates)))]
     (into estates
           (for [id missing]
-            [id (fetch-estate-info ctx id)]))))
+            [id (fetch-and-cache-estate-info ctx id)]))))
 
 (defn ensure-cached-estate-info
   "Ensure the given estates are in the cache and fetch/store it if not."

--- a/app/backend/src/clj/teet/integration/x_road/property_registry.clj
+++ b/app/backend/src/clj/teet/integration/x_road/property_registry.clj
@@ -68,13 +68,11 @@
 (defn d-property-owners [kdr-xml]
   ;;; kdr = Kinnistu_DetailamdResponse from inside the soap body
   (let [owner-xml-seq (z/xml-> kdr-xml :jagu2 :a:Jagu2 :a:omandiosad :a:Jagu2.Omandiosa)
-        ;; _ (def *ox owner-xml-seq)
         oo-get (fn oo-get [ox & path]
                   (apply z/xml1-> (concat [ox] path)))
         omandi-get (fn [ox & path] (apply oo-get ox (concat path [text])))]
     {:omandiosad
      (mapv (fn [ox]
-             (log/debug "ki count " (count  (z/xml-> ox :a:isikud :a:KinnistuIsik z/text)))
              {:isik (mapv (fn [k-isik]
                             {:isiku_tyyp (z/xml1-> k-isik :a:isiku_tyyp z/text)
                              :isiku_liik_id (z/xml1-> k-isik :a:isiku_liik_ID z/text)

--- a/app/backend/src/clj/teet/land/land_queries.clj
+++ b/app/backend/src/clj/teet/land/land_queries.clj
@@ -58,34 +58,6 @@
           (map :properties
                (:features units))))))
 
-(defquery :land/estate-info
-  {:doc "Fetch estate info from local cache or X-road"
-   :context {:keys [user]}
-   :args {estate-id :estate-id
-          project-id :thk.project/id}
-   :project-id [:thk.project/id project-id]
-   :config {xroad-instance [:xroad :instance-id]
-            xroad-url [:xroad :query-url]
-            xroad-subsystem [:xroad :kr-subsystem-id]
-            api-url [:api-url]
-            api-secret [:auth :jwt-secret]}
-   :authorization {:land/view-cadastral-data {:eid [:thk.project/id project-id]
-                                              :link :thk.project/owner}}}
-  (let [x-road-response (property-registry/fetch-estate-info
-                         {:xroad-url xroad-url
-                          :xroad-kr-subsystem-id xroad-subsystem
-                          :instance-id xroad-instance
-                          :requesting-eid (str "EE" (:user/person-id user))
-                          :api-url api-url
-                          :api-secret api-secret}
-                         estate-id)]
-    (if (= (:status x-road-response) :ok)
-      (-> x-road-response
-          property-registry/active-jagu34-only
-          (assoc :estate-id estate-id))
-      (throw (ex-info "Invalid xroad response" {:error :invalid-x-road-response
-                                                :response x-road-response})))))
-
 (defn- with-quality [{:keys [MOOTVIIS MUUDET] :as unit}]
   (assoc unit :quality
          (cond
@@ -201,6 +173,4 @@ and the compensation info as the value."
           db user [:thk.project/id id] sequence-number)))
 
 (defmethod link-db/fetch-external-link-info :estate [_user _ id]
-  ;; PENDING: estates have no name, show just the id
-  #_(property-registry/fetch-estate-info (property-registry-context user) id)
   {:estate-id id})

--- a/ci/browser-tests/cypress/integration/land_section.spec.js
+++ b/ci/browser-tests/cypress/integration/land_section.spec.js
@@ -5,8 +5,8 @@ context('Land section', () => {
       cy.get("#language-select").select("ET")
       cy.get("#password-textfield").type(Cypress.env("SITE_PASSWORD"));
       cy.get("button").contains("Login as Benjamin Boss").click();
-      
-      cy.contains('Minu projektid');      
+
+      cy.contains('Minu projektid');
     })
 
   it("select project", () => {
@@ -18,7 +18,7 @@ context('Land section', () => {
     cy.get("p").contains("Aruvalla").click();
     cy.get("main span.MuiIconButton-label > span.material-icons").click();
     cy.get("li.MuiButtonBase-root:nth-child(6) > div:nth-child(1)").click();
-    cy.contains("Vaatan omanike andmeid", {timeout: 20000}).click();
+    cy.contains("Vaatan omanike andmeid", {timeout: 120000}).click();
     cy.contains("Omanikud ja omandiosad");
   });
 


### PR DESCRIPTION
This PR fixes a bug where fetching cached xroad info occasionally fails due to a bug in rarely used codepath. It also prunes codepaths that end up making requests to xroad and removes unused code.