### PR TITLE
Add default viewport config for the config used when tests are run in…

### DIFF
--- a/ci/browser-tests/cypress.json
+++ b/ci/browser-tests/cypress.json
@@ -4,5 +4,7 @@
      "configFile": "reporterOpts.json"
  },
  "ignoreTestFiles": "**/*.ci.spec.js",
+ "viewportWidth": 1280,
+ "viewportHeight": 800,
  "retries": 5
 }


### PR DESCRIPTION
… AWS
![image](https://user-images.githubusercontent.com/24251864/113124165-e6463600-921d-11eb-9203-f2dae0587973.png)
We noticed that the viewport was less than the breakpoint for mobile view when tests are run in AWS against dev.
This should hopefully change it and maybe land_section tests will start passing again.