### PR TITLE
TEET-1509 don't store THK update timestamps

### DIFF
--- a/app/backend/src/clj/teet/thk/thk_import.clj
+++ b/app/backend/src/clj/teet/thk/thk_import.clj
@@ -42,7 +42,9 @@
 
 
 (defn integration-info [row fields]
-  (pr-str (select-keys row fields)))
+  (pr-str
+   (into (sorted-map)
+         (select-keys row fields))))
 
 (defn task-updates [rows]
   (into []

--- a/app/backend/src/clj/teet/thk/thk_mapping.clj
+++ b/app/backend/src/clj/teet/thk/thk_mapping.clj
@@ -95,16 +95,15 @@
 
 (def object-integration-info-fields
   #{:object/groupfk :object/groupname
-    :object/regionfk :object/thkupdstamp
-    :object/statusfk :object/statusname})
+    :object/regionfk :object/statusfk :object/statusname})
 
 (def phase-integration-info-fields
-  #{:phase/thkupdstamp :phase/cost :phase/typefk})
+  #{:phase/cost :phase/typefk})
 
 (def activity-integration-info-fields
   #{:activity/typefk :activity/shortname :activity/statusname
     :activity/contract
-    :activity/guaranteeexpired :activity/thkupdstamp :activity/cost})
+    :activity/guaranteeexpired :activity/cost})
 
 (def csv-column-names
   ["object_id"


### PR DESCRIPTION
THK seems to change update timestamps every time it imports CSV from TEET. This causes every object to be "changed" when they send it back and causes unnecessary transaction growth on TEET side.

Don't store the THK update timestamps in integration info (send them back empty) as THK doesn't seem to use them.
Also sorts the integration info by keys so it is stable.