### PR TITLE
TEET-1482 Unable to add cadastral units/restrictions by drawing a selection on the map

### DIFF
--- a/app/frontend/src/cljs/teet/project/project_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_view.cljs
@@ -569,7 +569,7 @@
         {:thk.project/keys [related-restrictions]} project]
     (e! (project-controller/->FetchRelatedCandidates buffer-m "restrictions"))
     (e! (project-controller/->FetchRelatedFeatures related-restrictions :restrictions)))
-  (fn [e! app {:keys [open-types checked-restrictions feature-candidates draw-selection-features] :or {open-types #{}} :as _project}]
+  (fn [e! app {:keys [open-types checked-restrictions feature-candidates] :or {open-types #{}} :as _project}]
     (let [buffer-m (get-in app [:map :road-buffer-meters])
           search-type (get-in app [:map :search-area :tab])
           {:keys [loading? restriction-candidates]} feature-candidates]
@@ -577,7 +577,6 @@
        open-types
        buffer-m
        {:restrictions restriction-candidates
-        :draw-selection-features draw-selection-features
         :search-type search-type
         :loading? loading?
         :checked-restrictions (or checked-restrictions #{})
@@ -591,7 +590,7 @@
         {:thk.project/keys [related-cadastral-units]} project]
     (e! (project-controller/->FetchRelatedCandidates buffer-m "cadastral-units"))
     (e! (project-controller/->FetchRelatedFeatures related-cadastral-units :cadastral-units)))
-  (fn [e! app {:keys [feature-candidates checked-cadastral-units draw-selection-features] :as _project}]
+  (fn [e! app {:keys [feature-candidates checked-cadastral-units] :as _project}]
     (let [buffer-m (get-in app [:map :road-buffer-meters])
           search-type (get-in app [:map :search-area :tab])
           {:keys [loading? cadastral-candidates]} feature-candidates]
@@ -599,7 +598,6 @@
        e!
        buffer-m
        {:cadastral-units cadastral-candidates
-        :draw-selection-features draw-selection-features
         :loading? loading?
         :search-type search-type
         :checked-cadastral-units (or checked-cadastral-units #{})

--- a/app/frontend/src/cljs/teet/ui/panels.cljs
+++ b/app/frontend/src/cljs/teet/ui/panels.cljs
@@ -141,7 +141,7 @@
                              [icons/navigation-close]]]
     [Dialog {:max-width max-width
              :full-width true
-             :open @open-atom
+             :open (boolean @open-atom)
              :on-close close-fn
              :data-cy data-cy}
      (if title


### PR DESCRIPTION
This PR fixes a bug which made it impossible to select cadastral units and restrictions by drawing the selected are on the map.

The fix replaces the use of `reagent.core/wrap` with the use of `reagent.core/cursor` and `reagent.ratom/make-reaction` to provide `panels/modal` with an atom-like object that behaves in the way we want.

One downside of the fix here is that `draw-selection` component now directly accesses the app state by constructing the cursor. However, all the events used from the `teet.project.project-controller` do the same.