### PR TITLE
TEET-1438 Backup/restore: skip empty transactions

### DIFF
--- a/app/backend/src/clj/teet/backup/backup_ion.clj
+++ b/app/backend/src/clj/teet/backup/backup_ion.clj
@@ -127,6 +127,7 @@
   "Internal datomic stuff that we can skip"
   #{:db.install/attribute})
 
+
 (defn- output-tx [db-ref attr-info-cache {:keys [data]} ignore-attributes]
   (let [datoms (for [{:keys [e a v added]} data
                      :let [{:db/keys [ident]}
@@ -203,7 +204,8 @@
     (doseq [tx (all-transactions conn)
             :let [tx-map (output-tx (delay (d/as-of db (:t tx))) attr-ident-cache tx
                                     ignore-attributes)]
-            :when (.after (get-in tx-map [:tx :db/txInstant]) backup-start)]
+            :when (and (seq (:data tx-map))
+                       (.after (get-in tx-map [:tx :db/txInstant]) backup-start))]
       (out! tx-map)
       (progress!))))
 
@@ -300,6 +302,14 @@
            :asset-old->new (result "assets.edn"))))
 
 
+(defn- write-backup-to-zip-file [conn file]
+  (with-open [out (io/output-stream file)]
+    (output-zip out
+                ["transactions.edn" (partial output-all-tx conn)]
+                (when (environment/feature-enabled? :asset-db)
+                  ["assets.edn" (partial output-all-tx
+                                         (environment/asset-connection))]))))
+
 (defn- backup* [_event]
   (let [bucket (environment/config-value :backup :bucket-name)
         env (environment/config-value :env)
@@ -313,12 +323,7 @@
     (try
       (let [file (java.io.File/createTempFile "backup" ".zip")]
         (log/info "Generating backup zip file: " (.getAbsolutePath file))
-        (with-open [out (io/output-stream file)]
-          (output-zip out
-                      ["transactions.edn" (partial output-all-tx conn)]
-                      (when (environment/feature-enabled? :asset-db)
-                        ["assets.edn" (partial output-all-tx
-                                               (environment/asset-connection))])))
+        (write-backup-to-zip-file conn file)
         (log/info "Backup generated in " (int (/ (- (System/currentTimeMillis) start-ms) 1000))
                   "seconds with size " (.length file)
                   ". Uploading to S3.")

--- a/app/backend/test/teet/backup/backup_ion_test.clj
+++ b/app/backend/test/teet/backup/backup_ion_test.clj
@@ -181,11 +181,22 @@
       (fn []
         (is (= items-before (list-items)))))))
 
+(defn no-empty-transactions []
+  (let [uuid (java.util.UUID/randomUUID)]
+    (tu/tx {:db/id "datomic.tx" :tx/author uuid})
+    (fn []
+      (is (empty? (d/q '[:find ?e
+                         :in $ ?uuid
+                         :where
+                         [?e :tx/author ?uuid]]
+                       (tu/db) uuid))))))
+
 ;; Add any new test setup/verify functions here
 (def test-parts [#'file-user-seen
                  #'task-and-comment
                  #'compare-project-pull
-                 #'asset-db-schema])
+                 #'asset-db-schema
+                 #'no-empty-transactions])
 
 (deftest restore-tx-backup
   (let [with-populated-db (tu/with-db)

--- a/app/backend/test/teet/backup/backup_ion_test.clj
+++ b/app/backend/test/teet/backup/backup_ion_test.clj
@@ -181,7 +181,11 @@
       (fn []
         (is (= items-before (list-items)))))))
 
-(defn no-empty-transactions []
+(defn no-empty-transactions
+  "Add a transaction containing only transaction metadata, return a
+  function which ensures that said transaction is not present in the
+  restored db"
+  []
   (let [uuid (java.util.UUID/randomUUID)]
     (tu/tx {:db/id "datomic.tx" :tx/author uuid})
     (fn []


### PR DESCRIPTION
This PR changes the backup functionality so that empty transactions, i.e. transactions containing only metadata about the transaction itself, are not backed up.