### PR TITLE
TEET-1482 Use integration/id when adding search geometries

### DIFF
--- a/app/backend/src/clj/teet/gis/entity_features.clj
+++ b/app/backend/src/clj/teet/gis/entity_features.clj
@@ -32,7 +32,7 @@
                              :properties properties}))})]
     (when (not= (:status response) 200)
       (throw (ex-info "entity info upsert failed" {:response response
-                                                   :entity-id entity-id
+                                                   :entity-id (str entity-id)
                                                    :features features})))
     :ok))
 

--- a/app/backend/src/clj/teet/project/project_commands.clj
+++ b/app/backend/src/clj/teet/project/project_commands.clj
@@ -16,6 +16,7 @@
             [teet.user.user-model :as user-model]
             [teet.user.user-spec :as user-spec]
             [teet.util.datomic :as du]
+            [teet.integration.integration-id :as integration-id]
             [teet.integration.x-road.property-registry :as property-registry]
             [teet.integration.postgrest :as postgrest])
   (:import (java.util Date UUID)))
@@ -189,7 +190,9 @@
    :pre [(string? id)]}
   (let [config (environment/config-map {:api-url [:api-url]
                                         :api-secret [:auth :jwt-secret]})
-        entity-id (:db/id (du/entity db [:thk.project/id id]))
+        entity-id (-> (du/entity db [:thk.project/id id])
+                      :integration/id
+                      integration-id/uuid->number)
         features [{:label geometry-label
                    :id (str (UUID/randomUUID))
                    :geometry geometry

--- a/app/frontend/src/cljs/teet/project/search_area_controller.cljs
+++ b/app/frontend/src/cljs/teet/project/search_area_controller.cljs
@@ -29,7 +29,7 @@
 
 (defn fetch-drawn-areas
   [app]
-  (let [entity-id (str (get-in app [:route :project :db/id]))]
+  (let [entity-id (str (get-in app [:route :project :integration/id]))]
     {:tuck.effect/type :rpc
      :rpc "geojson_entity_features_by_type"
      :endpoint (get-in app [:config :api-url])


### PR DESCRIPTION
This PR fixes an issue where `:db/id` was used instead of `:integration/id` when adding search geometries.