### PR TITLE
Cancel component add fix

### DIFF
--- a/app/frontend/src/cljs/teet/routes.cljs
+++ b/app/frontend/src/cljs/teet/routes.cljs
@@ -86,7 +86,10 @@
                      event-leave (on-leave-event {:current-app app
                                                   :page (:page app)
                                                   :params (:params app)
-                                                  :query (:query app)})
+                                                  :query (:query app)
+                                                  :new-page route-name
+                                                  :new-params params
+                                                  :new-query query})
                      event-leave (if (vector? event-leave) event-leave [event-leave])
                      event-to (on-navigate-event navigation-data)
                      event-to (if (vector? event-to) event-to [event-to])


### PR DESCRIPTION
When navigating away from add component form, cleanup the app state.