### PR TITLE
TEET-1416 Fix authorization of opinion edits and deletes

### DIFF
--- a/app/backend/resources/authorization.edn
+++ b/app/backend/resources/authorization.edn
@@ -109,6 +109,8 @@
   :internal-consultant :link,
   :external-consultant :link,
   :authenticated-guest :link},
+ :cooperation/edit-opinion
+ {:admin :full, :manager :full, :internal-consultant :full},
  :land/create-land-acquisition {:admin :full, :manager :full},
  :project/edit-permissions
  {:admin :full, :manager :full, :external-consultant :link},

--- a/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
+++ b/app/backend/src/clj/teet/cooperation/cooperation_commands.clj
@@ -208,7 +208,7 @@
    :context {:keys [user db]}
    :payload {:keys [application-id opinion-form]}
    :project-id (cooperation-db/application-project-id db application-id)
-   :authorization {:cooperation/edit-application {}}
+   :authorization {:cooperation/edit-opinion {}}
    :pre [(opinion-id-matches db application-id (:db/id opinion-form))]
    :transact
    (db-api-large-text/store-large-text!
@@ -288,5 +288,5 @@
    :context {:keys [user db]}
    :payload {:keys [application-id opinion-id]}
    :project-id (cooperation-db/application-project-id db application-id)
-   :authorization {:cooperation/edit-application {}}
+   :authorization {:cooperation/edit-opinion {}}
    :transact [[:db/retractEntity opinion-id]]})

--- a/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
+++ b/app/frontend/src/cljs/teet/cooperation/cooperation_view.cljs
@@ -1012,7 +1012,7 @@
                                  :project-id project-db-id})
       :response-uploads-allowed (cooperation-model/application-response-editable? application)
       :save-opinion (authorization-check/authorized?
-                      {:functionality :cooperation/edit-application
+                      {:functionality :cooperation/edit-opinion
                        :entity application
                        :project-id project-db-id})}
      [:div.cooperation-application-page {:class (<class common-styles/flex-column-1)}


### PR DESCRIPTION
This PR fixes the opinion authorization to work as follows:
- Only TA people (admin, manager, internal consultant) can add, edit and delete application opinions