### PR TITLE
TEET-1616 separate ATL and WFS queries

### DIFF
--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -79,13 +79,19 @@
     (child-ctypes db x)
     x))
 
+(defn last-atl-modification-time [db]
+  (ffirst
+   (d/q '[:find (max ?txi)
+          :where
+          [_ :tx/schema-imported-at _ ?tx]
+          [?tx :db/txInstant ?txi]] db)))
+
 (defn asset-type-library [db]
   (walk/postwalk
    (fn [x]
      (->> x
           remove-empty-selection-attributes
           (pull-child-ctypes db)))
-
    {:tx/schema-imported-at (ffirst
                             (d/q '[:find (max ?t)
                                    :where [_ :tx/schema-imported-at ?t]]

--- a/app/backend/src/clj/teet/asset/asset_queries.clj
+++ b/app/backend/src/clj/teet/asset/asset_queries.clj
@@ -19,10 +19,11 @@
 
 (defquery :asset/type-library
   {:doc "Query the asset types"
-   :context _
+   :context {adb :asset-db}
    :unauthenticated? true
-   :args _}
-  (asset-db/asset-type-library (environment/asset-db)))
+   :args _
+   :last-modified (asset-db/last-atl-modification-time adb)}
+  (asset-db/asset-type-library adb))
 
 (defn- fetch-cost-item [adb oid]
   (asset-type-library/db->form

--- a/app/backend/src/clj/teet/asset/asset_queries.clj
+++ b/app/backend/src/clj/teet/asset/asset_queries.clj
@@ -50,13 +50,33 @@
    {}
    cost-groups))
 
+(defquery :asset/project-relevant-roads
+  {:doc "Query project's relevant roads"
+   :context {:keys [db user] adb :asset-db}
+   :args {project-id :thk.project/id}
+   :project-id [:thk.project/id project-id]
+   :authorization {:project/read-info {}}}
+  ;; Fetch relevant roads for cost items of project, meaning the
+  ;; project road along with roads intersecting project geometry
+  ;; with a buffer of 50 meters.
+  ;;
+  ;; This can take some time, so it should be fetched once.
+  ;; Could be cached per project as well.
+  (let [integration-id (project-db/thk-id->integration-id-uuid db project-id)
+        ctx (environment/config-map {:api-url [:api-url]
+                                     :api-secret [:auth :jwt-secret]
+                                     :wfs-url [:road-registry :wfs-url]})]
+    (road-query/fetch-relevant-roads-for-project-cost-items
+     ctx
+     integration-id
+     relevant-roads-buffer-meters)))
+
 (defquery :asset/project-cost-items
   {:doc "Query project cost items"
    :context {:keys [db user] adb :asset-db}
    :args {project-id :thk.project/id
           cost-item :cost-item
           cost-totals :cost-totals
-          relevant-roads :relevant-roads
           road :road}
    :project-id [:thk.project/id project-id]
    ;; fixme: cost items authz
@@ -65,8 +85,7 @@
     (transit/with-write-options
       euro/transit-type-handlers
       (merge
-       {:asset-type-library atl
-        :cost-items (asset-db/project-cost-items adb project-id)
+       {:cost-items (asset-db/project-cost-items adb project-id)
         :version (asset-db/project-boq-version adb project-id)
         :latest-change (when-let [[timestamp author] (asset-db/latest-change-in-project adb project-id)]
                          {:user (user-db/user-display-info db [:user/id author])
@@ -89,19 +108,7 @@
                       ;; PENDING: what if there are thousands?
                       (if (asset-model/component-oid? cost-item)
                         (asset-model/component-asset-oid cost-item)
-                        cost-item))})
-       ;; Fetch relevant roads for cost items of project, meaning the
-       ;; project road along with roads intersecting project geometry
-       ;; with a buffer of 50 meters.
-       (when relevant-roads
-         {:relevant-roads
-          (when-let [integration-id (project-db/thk-id->integration-id-uuid db project-id)]
-            (let [ctx (environment/config-map {:api-url [:api-url]
-                                               :api-secret [:auth :jwt-secret]
-                                               :wfs-url [:road-registry :wfs-url]})]
-              (road-query/fetch-relevant-roads-for-project-cost-items ctx
-                                                                      integration-id
-                                                                      relevant-roads-buffer-meters)))})))))
+                        cost-item))})))))
 
 (s/def :boq-export/version integer?)
 (s/def :boq-export/unit-prices? boolean?)

--- a/app/backend/src/clj/teet/db_api/core.clj
+++ b/app/backend/src/clj/teet/db_api/core.clj
@@ -82,6 +82,11 @@
          assoc request-name
          permissions))
 
+(defmacro with-last-modified [last-modified-code body]
+  `(with-meta
+     {:body (delay ~body)}
+     {:last-modified ~last-modified-code}))
+
 (defmacro defrequest*
   "Do not call directly. Use defcommand and defquery."
   [request-type request-name
@@ -189,22 +194,24 @@
                                        :msg "Pre check failed"
                                        :error ~error
                                        :pre-check ~(str pre)}))))
+               (~@(if-let [last-modified (:last-modified options)]
+                    (list `with-last-modified last-modified)
+                    (list `identity))
+                (let [~'%
+                      ~(if (and (= :command request-type) transact)
+                         `(select-keys (tx ~transact)
+                                       [:tempids])
+                         `(do ~@body))]
 
-               (let [~'%
-                     ~(if (and (= :command request-type) transact)
-                        `(select-keys (tx ~transact)
-                                      [:tempids])
-                        `(do ~@body))]
-
-                 ~@(for [post (:post options)]
-                     `(when-not ~post
-                        (throw (ex-info "Post check failed"
-                                        {:status 500
-                                         :msg "Internal server error"
-                                         :error :request-post-check-failed
-                                         :post-check ~(str post)}))))
-                 ;; Return result
-                 ~'%)))))))
+                  ~@(for [post (:post options)]
+                      `(when-not ~post
+                         (throw (ex-info "Post check failed"
+                                         {:status 500
+                                          :msg "Internal server error"
+                                          :error :request-post-check-failed
+                                          :post-check ~(str post)}))))
+                  ;; Return result
+                  ~'%))))))))
 
 (defmacro defcommand
   "Define a command.

--- a/app/backend/src/clj/teet/db_api/db_api_handlers.clj
+++ b/app/backend/src/clj/teet/db_api/db_api_handlers.clj
@@ -47,7 +47,8 @@
             [teet.log :as log]
             [teet.auth.jwt-token :as jwt-token]
             [clojure.string :as str]
-            [teet.user.user-db :as user-db]))
+            [teet.user.user-db :as user-db]
+            [ring.middleware.not-modified :as not-modified]))
 
 (defn- jwt-token [req]
   (or
@@ -69,51 +70,53 @@
     (deref-delay (get m k default-value))))
 
 (defn- request [handler-fn]
-  (fn [req]
-    (try
-      (let [user (some->> req jwt-token (jwt-token/verify-token
-                                         (environment/config-value :auth :jwt-secret)))]
-        (log/with-context
-          {:user (str (:user/id user))}
-          (let [conn (environment/datomic-connection)
-                db (d/db conn)
-                aconn (delay (environment/asset-connection))
-                ctx {:conn conn
-                     :db db
-                     :asset-conn aconn
-                     :asset-db (delay (d/db @aconn))
-                     :user (merge user
-                                  (when-let [user-id (:user/id user)]
-                                    (user-db/user-info db [:user/id user-id])))
-                     :session (:session req)}
-                request-payload (transit/transit-request req)
-                response (handler-fn ctx request-payload)]
-            (case (:format (meta response))
-              ;; If :format meta key is :raw, send output as ring response
-              :raw response
+  (not-modified/wrap-not-modified
+   (fn [req]
+     (try
+       (let [user (some->> req jwt-token (jwt-token/verify-token
+                                          (environment/config-value :auth :jwt-secret)))]
+         (log/with-context
+           {:user (str (:user/id user))}
+           (let [conn (environment/datomic-connection)
+                 db (d/db conn)
+                 aconn (delay (environment/asset-connection))
+                 ctx {:conn conn
+                      :db db
+                      :asset-conn aconn
+                      :asset-db (delay (d/db @aconn))
+                      :user (merge user
+                                   (when-let [user-id (:user/id user)]
+                                     (user-db/user-info db [:user/id user-id])))
+                      :session (:session req)
+                      :headers (:headers req)}
+                 request-payload (transit/transit-request req)
+                 response (handler-fn ctx request-payload)]
+             (case (:format (meta response))
+               ;; If :format meta key is :raw, send output as ring response
+               :raw response
 
-              ;; Default to sending out transit response
-              (transit/transit-response response)))))
-      (catch Exception e
-        (let [exd (ex-data e)
-              status (:status exd)
-              error (or (:error exd)
-                        (:teet/error exd))]
-          (case error
-            ;; Return JWT verification failures (likely expired token) as 401 (same as PostgREST)
-            :jwt-verification-failed
-            (do
-              (log/info "JWT verification failed: " (ex-data e))
-              {:status 401
-               :body "JWT verification failed"})
+               ;; Default to sending out transit response
+               (transit/transit-response response)))))
+       (catch Exception e
+         (let [exd (ex-data e)
+               status (:status exd)
+               error (or (:error exd)
+                         (:teet/error exd))]
+           (case error
+             ;; Return JWT verification failures (likely expired token) as 401 (same as PostgREST)
+             :jwt-verification-failed
+             (do
+               (log/info "JWT verification failed: " (ex-data e))
+               {:status 401
+                :body "JWT verification failed"})
 
-            ;; Log all other errors, but don't return exception info to client
-            (do
-              (log/error e "Exception in handler")
-              (merge {:status (or status 500)
-                      :body "Internal server error, see log for details"}
-                     (when (keyword? error)
-                       {:headers {"X-TEET-Error" (name error)}})))))))))
+             ;; Log all other errors, but don't return exception info to client
+             (do
+               (log/error e "Exception in handler")
+               (merge {:status (or status 500)
+                       :body "Internal server error, see log for details"}
+                      (when (keyword? error)
+                        {:headers {"X-TEET-Error" (name error)}}))))))))))
 
 (defn- check-spec [spec data]
   (if (nil? (s/get-spec spec))

--- a/app/backend/src/clj/teet/transit.clj
+++ b/app/backend/src/clj/teet/transit.clj
@@ -1,7 +1,8 @@
 (ns teet.transit
   "Transit format utilities"
   (:require [cognitect.transit :as t]
-            [teet.util.collection :as cu])
+            [teet.util.collection :as cu]
+            [ring.util.io :as ring-io])
   (:import (com.cognitect.transit WriteHandler)))
 
 (defn transit->clj
@@ -38,9 +39,18 @@
     (.toString out "UTF-8")))
 
 (defn transit-response [data]
-  {:status 200
-   :headers {"Content-Type" "application/json+transit"}
-   :body (clj->transit data)})
+  (let [last-modified (some-> data meta :last-modified)
+        body (if last-modified
+               ;; We have last-modified, data :body is a delay
+               (ring-io/piped-input-stream
+                (fn [out]
+                  (write-transit out @(:body data))))
+               (clj->transit data))]
+    {:status 200
+     :headers (merge {"Content-Type" "application/json+transit"}
+                     (when last-modified
+                       {"Last-Modified" last-modified}))
+     :body body}))
 
 (defn transit-request [{:keys [body params request-method] :as _req}]
   (case request-method

--- a/app/backend/src/clj/teet/transit.clj
+++ b/app/backend/src/clj/teet/transit.clj
@@ -2,7 +2,8 @@
   "Transit format utilities"
   (:require [cognitect.transit :as t]
             [teet.util.collection :as cu]
-            [ring.util.io :as ring-io])
+            [ring.util.io :as ring-io]
+            [ring.util.time :as ring-time])
   (:import (com.cognitect.transit WriteHandler)))
 
 (defn transit->clj
@@ -49,7 +50,8 @@
     {:status 200
      :headers (merge {"Content-Type" "application/json+transit"}
                      (when last-modified
-                       {"Last-Modified" last-modified}))
+                       {"Last-Modified" (ring-time/format-date last-modified)
+                        "Cache-Control" "must-revalidate"}))
      :body body}))
 
 (defn transit-request [{:keys [body params request-method] :as _req}]

--- a/app/frontend/resources/routes.edn
+++ b/app/frontend/resources/routes.edn
@@ -217,7 +217,5 @@
  :asset-type-library
  {:path "/asset/type-library"
   :view teet.asset.asset-library-view/asset-library-page
-  :crumb (tr [:asset :type-library-label])
-  :state {:query :asset/type-library
-          :args {}}}
+  :crumb (tr [:asset :type-library-label])}
  }

--- a/app/frontend/resources/routes.edn
+++ b/app/frontend/resources/routes.edn
@@ -180,7 +180,6 @@
   :state {:query :asset/project-cost-items
           :args {:thk.project/id project
                  :cost-totals true
-                 :relevant-roads true
                  :road (some-> query-params :road ->long)}}}
 
  :cost-item
@@ -190,8 +189,7 @@
   :state {:query :asset/project-cost-items
           :args {:thk.project/id project
                  :cost-item (let [oid (params :id)]
-                              (when (not= oid "new") oid))
-                 :relevant-roads true}}}
+                              (when (not= oid "new") oid))}}}
 
  :unauthorized
  {:path "/unauthorized" :view teet.ui.unauthorized/restricted-path}

--- a/app/frontend/src/cljs/teet/asset/asset_library_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/asset_library_view.cljs
@@ -6,7 +6,7 @@
             [teet.ui.table :as table]
             [teet.util.collection :as cu]
             [teet.ui.material-ui :refer [Card CardHeader CardContent IconButton
-                                         Paper Grid]]
+                                         Paper Grid CircularProgress]]
             [teet.ui.icons :as icons]
             [teet.util.datomic :as du]
             [teet.common.common-styles :as common-styles]
@@ -184,7 +184,7 @@
 (defn- focus-on-ident [app]
   (some->> app :query :item cljs.reader/read-string))
 
-(defn asset-library-page [_e! app atl]
+(defn asset-library-page [_e! {atl :asset-type-library :as app}]
   (let [open (r/atom #{})
         toggle! #(swap! open cu/toggle %)
         focus (atom (focus-on-ident app))]
@@ -196,34 +196,36 @@
             (ensure-tree-open atl open new-focus)
             (reset! focus new-focus))))
       :reagent-render
-      (fn [_e! _app {:keys [fgroups] common :ctype/common
-                     modified :tx/schema-imported-at
-                     :as atl}]
-        [:<>
-         [:div {:class (<class common-styles/flex-row-space-between)
-                :style {:align-items :center}}
-
-          [typography/Heading1 (tr [:asset :type-library :header])]
-          (when modified
-            [:div {:style {:margin "1rem"}}
-             (tr [:common :last-modified]) ": "
-             (format/date-time modified)])]
-         [Paper {}
-          [Grid {:container true :spacing 0 :wrap :wrap}
-           [scrollable-grid 4
+      (fn [_e! {atl :asset-type-library :as _app}]
+        (if-not atl
+          [CircularProgress {}]
+          (let [{:keys [fgroups] common :ctype/common
+                 modified :tx/schema-imported-at} atl]
             [:<>
-             ^{:key "common"}
-             [rotl-tree {:open @open :toggle! toggle!
-                         :focus @focus
-                         :label (tr [:asset :type-library :common-ctype])} common]
-             (doall
-              (for [fg fgroups]
-                ^{:key (str (:db/ident fg))}
-                [rotl-tree {:open @open :toggle! toggle! :focus @focus} fg]))]]
-           [scrollable-grid 8
-            [:div {:style {:padding "1rem"}}
-             (when-let [item-kw @focus]
-               (let [item (if (= item-kw :ctype/common)
-                            common
-                            (asset-type-library/item-by-ident atl item-kw))]
-                 [rotl-item item]))]]]]])})))
+             [:div {:class (<class common-styles/flex-row-space-between)
+                    :style {:align-items :center}}
+
+              [typography/Heading1 (tr [:asset :type-library :header])]
+              (when modified
+                [:div {:style {:margin "1rem"}}
+                 (tr [:common :last-modified]) ": "
+                 (format/date-time modified)])]
+             [Paper {}
+              [Grid {:container true :spacing 0 :wrap :wrap}
+               [scrollable-grid 4
+                [:<>
+                 ^{:key "common"}
+                 [rotl-tree {:open @open :toggle! toggle!
+                             :focus @focus
+                             :label (tr [:asset :type-library :common-ctype])} common]
+                 (doall
+                  (for [fg fgroups]
+                    ^{:key (str (:db/ident fg))}
+                    [rotl-tree {:open @open :toggle! toggle! :focus @focus} fg]))]]
+               [scrollable-grid 8
+                [:div {:style {:padding "1rem"}}
+                 (when-let [item-kw @focus]
+                   (let [item (if (= item-kw :ctype/common)
+                                common
+                                (asset-type-library/item-by-ident atl item-kw))]
+                     [rotl-item item]))]]]]])))})))

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -9,9 +9,27 @@
             [teet.asset.asset-model :as asset-model]
             [teet.routes :as routes]
             cljs.reader
-            [teet.asset.asset-type-library :as asset-type-library]))
+            [teet.asset.asset-type-library :as asset-type-library]
+            [reagent.core :as r]))
 
 (defrecord AddComponentCancel [id])
+
+(defrecord MaybeFetchAssetTypeLibrary []
+  t/Event
+  (process-event [_ app]
+    (if (:asset-type-library app)
+      app
+      (t/fx app
+            {:tuck.effect/type :query
+             :query :asset/type-library
+             :args {}
+             :result-path [:asset-type-library]}))))
+
+;; Register routes that need asset type library to be in app state
+;; and launch event to fetch it when navigating.
+(doseq [r [:cost-item :cost-items :cost-items-totals :asset-type-library]]
+  (defmethod routes/on-navigate-event r [_] (->MaybeFetchAssetTypeLibrary)))
+
 
 (defmethod routes/on-leave-event :cost-item [{:keys [query new-query]}]
   (when (and (:component query)

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -186,8 +186,7 @@
       form-update-data)
     form-update-data))
 
-(defn- app->relevant-roads [app]
-  (-> app :route :cost-item :relevant-roads))
+(declare project-relevant-roads)
 
 (extend-protocol t/Event
 
@@ -282,10 +281,11 @@
         (log/debug "Not editing form, BOQ version is locked.")
         app)
       (let [old-form (form-state app)
-            new-form (cu/deep-merge old-form
-                                    (default-carriageway form-data
-                                                         old-form
-                                                         (app->relevant-roads app)))]
+            new-form (cu/deep-merge
+                      old-form
+                      (default-carriageway form-data
+                                           old-form
+                                           (project-relevant-roads (get-in app [:params :project]))))]
         (process-location-change
          (update-form app (constantly new-form))
          old-form new-form))))
@@ -507,7 +507,7 @@
            :page (:page app)
            :params (:params app)
            :query (if road
-                    {:road (:road-nr road)}
+                    {:road road}
                     {})})))
 
 (extend-protocol t/Event
@@ -575,3 +575,32 @@
 
             (filter filter-pred))
            cost-group-totals)]))
+
+
+(def relevant-road-cache
+  "Atom to cache relevant roads by project."
+  (r/atom {}))
+
+(defn- project-relevant-roads
+  "Get relevant roads for project that have been fetched previously."
+  [project-id]
+  (get @relevant-road-cache project-id))
+
+(defrecord FetchRelevantRoadsResponse [project-id response]
+  t/Event
+  (process-event [_ app]
+    (swap! relevant-road-cache assoc project-id response)
+    app))
+
+(defrecord FetchRelevantRoads [project-id]
+  t/Event
+  (process-event [_ app]
+    (if (contains? @relevant-road-cache project-id)
+      app
+      (do
+        (swap! relevant-road-cache assoc project-id [])
+        (t/fx app
+              {:tuck.effect/type :query
+               :query :asset/project-relevant-roads
+               :args {:thk.project/id project-id}
+               :result-event (partial ->FetchRelevantRoadsResponse project-id)})))))


### PR DESCRIPTION
Asset type library is a large payload (146kb at this time and growing with time). Separate that to another query and fetch it only once when navigating to any view that needs it.

Query for relevant roads of a project uses external WFS service that may take a long time (depending on road length of project). Fetch that on demand for the project as needed and only once.