### PR TITLE
TEET-1227 fix hard coded activity name in the contract target listing

### DIFF
--- a/app/frontend/src/cljs/teet/contract/contract_view.cljs
+++ b/app/frontend/src/cljs/teet/contract/contract_view.cljs
@@ -73,7 +73,7 @@
          [(get-in target [:activity :activity/manager])]]
         [[(get-in target [:project :thk.project/name])]
          [[url/Link (:target-navigation-info target)
-           (get-in target [:target :activity/name])]]
+           (tr [:enum (get-in target [:target :activity/name])])]]
          [nil]
          [(get-in target [:activity :activity/manager])]]))]])
 


### PR DESCRIPTION
fix to use translation instead of enum value.