### PR TITLE
TEET-1580 no road reference

### DIFF
--- a/app/backend/src/clj/teet/asset/asset_queries.clj
+++ b/app/backend/src/clj/teet/asset/asset_queries.clj
@@ -16,7 +16,8 @@
             [teet.util.euro :as euro]
             [clojure.spec.alpha :as s]
             [clojure.string :as str]
-            [cheshire.core :as cheshire]))
+            [cheshire.core :as cheshire]
+            [teet.util.coerce :refer [->long]]))
 
 (defquery :asset/type-library
   {:doc "Query the asset types"
@@ -96,7 +97,15 @@
          (let [cost-groups (asset-db/project-cost-groups-totals
                             adb project-id
                             (when road
-                              (asset-db/project-assets-and-components-matching-road adb project-id road)))]
+                              (cond
+                                (= road "all-roads")
+                                (asset-db/project-assets-and-components-with-road adb project-id)
+
+                                (= road "no-road-reference")
+                                (asset-db/project-assets-and-components-without-road adb project-id)
+                                :else
+                                (asset-db/project-assets-and-components-matching-road
+                                 adb project-id (->long road)))))]
            {:cost-totals
             {:cost-groups cost-groups
              :fclass-and-fgroup-totals (fclass-and-fgroup-totals atl cost-groups)

--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -57,13 +57,14 @@
   "The Cost Item list is in the Contract phase, are you sure that you want to change it, and are you aware that you need to change the budget and inform the management",
   :totals-table
   {:properties "Cost grouping",
-   :type "Type",
-   :quantity "Quantity",
+   :project-total "Total {total} EUR",
    :cost-per-quantity-unit "Unit cost (€)",
    :total-cost "Total (€)",
-   :project-total "Total {total} EUR",
+   :type "Type",
    :all-components "All components",
-   :all-roads "All roads"},
+   :all-roads "All roads",
+   :quantity "Quantity",
+   :no-road-reference "No road reference"},
   :add-cost-item "Add cost item",
   :export-boq "Export BOQ",
   :validate

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -57,13 +57,14 @@
   "Kululoend on aktiivses lepingus. Selle muutmine tähendab lepingu muudatust. Kas oled kindel, et soovid avada kululoendi muudatusteks?",
   :totals-table
   {:properties "Kulude grupeerimine",
-   :type "Tüüp",
-   :quantity "Kogus",
+   :project-total "Kokku {total} EUR",
    :cost-per-quantity-unit "Ühiku maksumus (€)",
    :total-cost "Kokku (€)",
-   :project-total "Kokku {total} EUR",
+   :type "Tüüp",
    :all-components "Kõik komponendid",
-   :all-roads "Kõik teed"},
+   :all-roads "Kõik teed",
+   :quantity "Kogus",
+   :no-road-reference "Ilma tee aadressita"},
   :add-cost-item "Lisan vara",
   :export-boq "Kululoendi eksport",
   :validate

--- a/app/frontend/resources/routes.edn
+++ b/app/frontend/resources/routes.edn
@@ -180,7 +180,7 @@
   :state {:query :asset/project-cost-items
           :args {:thk.project/id project
                  :cost-totals true
-                 :road (:road query-params)}}}
+                 :road (or (:road query-params) "all-roads")}}}
 
  :cost-item
  {:path "/projects/:project/cost-items/:id"

--- a/app/frontend/resources/routes.edn
+++ b/app/frontend/resources/routes.edn
@@ -180,7 +180,7 @@
   :state {:query :asset/project-cost-items
           :args {:thk.project/id project
                  :cost-totals true
-                 :road (some-> query-params :road ->long)}}}
+                 :road (:road query-params)}}}
 
  :cost-item
  {:path "/projects/:project/cost-items/:id"


### PR DESCRIPTION
Add "no road reference" option. "All roads" will only include assets that have a road (no matter what it is), "no road reference" includes only assets that are missing a road nr.
