### PR TITLE
TEET-1625 Cost item totals: price edit bug "server error"

### DIFF
--- a/app/backend/src/clj/teet/asset/asset_commands.clj
+++ b/app/backend/src/clj/teet/asset/asset_commands.clj
@@ -81,9 +81,13 @@
               (tempids id)
               id))))
 
-(defn- valid-cost-group-price? [price]
+(defn- valid-cost-group-price?
+  "We want the price to be
+   - non-negative
+   - max eurocent precision"
+  [price]
   (try (not (neg? (euro/parse price)))
-       (catch Exception e
+       (catch Exception _e
          false)))
 
 (defcommand :asset/save-cost-group-price

--- a/app/backend/src/clj/teet/asset/asset_commands.clj
+++ b/app/backend/src/clj/teet/asset/asset_commands.clj
@@ -81,6 +81,11 @@
               (tempids id)
               id))))
 
+(defn- valid-cost-group-price? [price]
+  (try (not (neg? (euro/parse price)))
+       (catch Exception e
+         false)))
+
 (defcommand :asset/save-cost-group-price
   {:doc "Save cost group price"
    :context {:keys [user db] adb :asset-db}
@@ -92,7 +97,10 @@
              (= project-id
                 (:cost-group/project (du/entity adb (:db/id cost-group)))))
          ^{:error :boq-is-locked}
-         (boq-unlocked? adb project-id)]}
+         (boq-unlocked? adb project-id)
+
+         ^{:error :invalid-price}
+         (valid-cost-group-price? price)]}
   (tx
    (if-let [id (:db/id cost-group)]
      ;; Compare and swap the price if there is an existing one

--- a/app/backend/src/clj/teet/db_api/core.clj
+++ b/app/backend/src/clj/teet/db_api/core.clj
@@ -337,6 +337,7 @@
        x))
    tx-data))
 
+
 (defn tx
   "Execute Datomic transaction inside defcommand. Automatically adds transaction info to the tx-data.
 

--- a/app/common/src/cljc/teet/util/euro.cljc
+++ b/app/common/src/cljc/teet/util/euro.cljc
@@ -22,7 +22,7 @@
      :cljs (.toLocaleString n js/undefined #js {:minimumFractionDigits 2
                                                 :maximumFractionDigits 2})))
 
-(def ^:private euro-pattern #"^-?\d+(\.\d{1,2})?")
+(def ^:private euro-pattern #"^-?\d+(\.\d{0,2})?")
 
 (defn parse
   "Parse string as euro number, string can contain whitespace and end with € symbol."

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -519,8 +519,7 @@
                                          :total-cost
                                          :quantity-unit :type
                                          :ui/group)
-                     ;; Interpret empty string as 0
-                     :price (if (str/blank? price) "0" price)}
+                     :price (if (str/blank? price) nil price)}
            :result-event (partial ->SaveCostGroupPriceResponse finish-saving!)
            :error-event (partial ->SaveCostGroupPriceError finish-saving!)}))
 

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -779,8 +779,9 @@
           {:title (tr [:common :last-modified])
            :variant :info
            :body [:<>
-                  [:div (fmt/date-time timestamp)]
-                  [:div (user-model/user-name user)]]}
+                  (fmt/date-time timestamp)
+                  [:br]
+                  (user-model/user-name user)]}
           [icons/alert-error-outline]])
 
        ;; Save or unlock button

--- a/app/frontend/src/cljs/teet/ui/common.cljs
+++ b/app/frontend/src/cljs/teet/ui/common.cljs
@@ -529,7 +529,7 @@
              :on-focus enter!
              :on-blur leave!
              :ref set-anchor-el!
-             :tabindex 0
+             :tabIndex 0
              :style {:display :inline-block}}
        component
        [Popper {:style {:z-index 1600}                      ;; z-index is not specified for poppers so they by default appear under modals


### PR DESCRIPTION
This PR implements the following fixes and improvements:
- Handle empty input by removing the price information
- Properly format field value after successful update
- Disable negative values for prices
- Set scale of prices to 2 decimal places, as Datomic strongly recommends having the same scale for all values of a given attribute.
- Fix case where price couldn't be updated back to previous value
- Fix case where text field remained disabled after attempting to input invalid price
- Fix case where text field remained disabled after successful update
- Fix case where inputting more than 2 decimal numbers results in updates failing due to failed CAS