### PR TITLE
Fix external links to Procurement registries

### DIFF
--- a/app/backend/src/clj/teet/environment.clj
+++ b/app/backend/src/clj/teet/environment.clj
@@ -139,7 +139,7 @@
               :config (->ssm [:vektorio :config] {} (comp #(update % :file-extensions suffix-list)
                                                       read-string))}
    :asset {:default-owner-code (->ssm [:asset :default-owner-code] "N40")}
-   :contract {:state-procurement-url (->ssm [:contact :state-procurement-url] nil)
+   :contract {:state-procurement-url (->ssm [:contract :state-procurement-url] nil)
               :thk-procurement-url (->ssm [:contract :thk-procurement-url] nil)}
    })
 

--- a/app/backend/src/clj/teet/login/login_commands.clj
+++ b/app/backend/src/clj/teet/login/login_commands.clj
@@ -69,7 +69,9 @@
   {:thk {:url (environment/config-value :thk :url)}
    :api-url (environment/config-value :api-url)
    :file {:allowed-suffixes (environment/config-value :file :allowed-suffixes)
-          :image-suffixes (environment/config-value :file :image-suffixes)}})
+          :image-suffixes (environment/config-value :file :image-suffixes)}
+   :contract {:state-procurement-url (environment/config-value :contract :state-procurement-url)
+              :thk-procurement-url (environment/config-value :contract :thk-procurement-url)}})
 
 ;; dummy-login trust person-id etc information from
 ;; the frontend (command could be renamed to dummy-login)


### PR DESCRIPTION
Implement queries for Procurement State registry and THK links as configuration SSM parameters are not available in frontend.