### PR TITLE
Direct JDBC calls instead of PostgREST

### DIFF
--- a/app/backend/deps.edn
+++ b/app/backend/deps.edn
@@ -37,13 +37,20 @@
 
         ;; Cognitect AWS API
         com.cognitect.aws/api {:mvn/version "0.8.456"}
-        com.cognitect.aws/endpoints {:mvn/version "1.1.11.789"}
-        com.cognitect.aws/email {:mvn/version "770.2.568.0"}
-        com.cognitect.aws/ssm {:mvn/version "798.2.672.0"}
-        com.cognitect.aws/s3 {:mvn/version "799.2.682.0"}
-        com.cognitect.aws/sts {:mvn/version "798.2.678.0"}
-        com.cognitect.aws/logs {:mvn/version "798.2.672.0"}}
+        com.cognitect.aws/endpoints {:mvn/version "1.1.11.1001"}
+        com.cognitect.aws/ssm {:mvn/version "811.2.889.0"}
+        com.cognitect.aws/s3 {:mvn/version "811.2.889.0"}
+        com.cognitect.aws/sts {:mvn/version "811.2.889.0"}
+        com.cognitect.aws/logs {:mvn/version "809.2.784.0"}
+        com.cognitect.aws/rds {:mvn/version "811.2.889.0"}
 
+        ;; PostgreSQL JDBC driver and SQL libraries
+        org.postgresql/postgresql {:mvn/version "42.2.20"}
+        com.zaxxer/HikariCP {:mvn/version "4.0.3"}
+        webjure/jeesql {:mvn/version "0.4.7"}
+
+
+        }
 
 
  :mvn/repos {"central" {:url "https://repo1.maven.org/maven2/"}

--- a/app/backend/dev-src/user.clj
+++ b/app/backend/dev-src/user.clj
@@ -8,7 +8,8 @@
             [clojure.string :as str]
             [clojure.walk :as walk]
             [datomic.dev-local :as dl]
-            [cognitect.aws.client.api :as aws])
+            [cognitect.aws.client.api :as aws]
+            [teet.project.project-geometry :as project-geometry])
   (:import (java.util Date)
            (java.util.concurrent TimeUnit Executors)))
 
@@ -441,4 +442,26 @@
       (import-cloud cloud-teet-db-name local-teet-db-name)
       (println "\nImporting asset db")
       (import-cloud cloud-asset-db-name local-asset-db-name)
-      (println "\nDone. Remember to change config.edn to use new databases."))))
+      (println "\nDone.\nRemember to:"
+               "\n  - change config.edn to use new databases."
+               "\n  - run update-project-geometries! with new db to sync PostgREST geometries"))))
+
+
+(defn update-project-geometries! []
+  (let [db (db)]
+    (project-geometry/update-project-geometries!
+     (merge {:db db}
+            (environment/config-map {:api-url [:api-url]
+                                     :api-secret [:auth :jwt-secret]
+                                     :wfs-url [:road-registry :wfs-url]}))
+     (map first
+          (d/q '[:find (pull ?e [:db/id :integration/id
+                                 :thk.project/project-name :thk.project/name
+                                 :thk.project/road-nr
+                                 :thk.project/carriageway
+                                 :thk.project/start-m :thk.project/end-m
+                                 :thk.project/custom-start-m :thk.project/custom-end-m])
+                 :in $
+                 :where [?e :thk.project/road-nr _]]
+               db)))
+    :ok))

--- a/app/backend/resources/datomic/ion-config.edn
+++ b/app/backend/resources/datomic/ion-config.edn
@@ -20,6 +20,7 @@
          teet.task.task-tx/delete-task
          teet.asset.asset-tx/save-asset
          teet.asset.asset-tx/save-component
+         teet.asset.asset-tx/import-asset
          teet.asset.asset-tx/lock]
  :lambdas {:query
            {:fn teet.db-api.db-api-ion/db-api-query

--- a/app/backend/src/clj/teet/asset/asset_road_registry_import.clj
+++ b/app/backend/src/clj/teet/asset/asset_road_registry_import.clj
@@ -1,0 +1,32 @@
+(ns teet.asset.asset-road-registry-import
+  "Import assets to TEET from road registry WFS.
+  Requires a mapping for an asset type that describes
+  what components are created and what fields go to
+  which attributes."
+  (:require [teet.road.road-query :as road-query]
+            [teet.map.map-services :as map-services]
+            [hiccup.core :as h]))
+
+
+(defn- road-registry-objects [config type gml-area]
+  (map-services/fetch-intersecting-objects-of-type
+   config type gml-area))
+
+(defn- gml-area [[x1 y1] [x2 y2]]
+  (h/html
+   [:gml:Polygon {:srsName "EPSG:3301"}
+    [:gml:outerBoundaryIs
+     [:gml:LinearRing
+      [:gml:coordinates
+       (str y1 "," x1 " "
+            y2 "," x1 " "
+            y2 "," x2 " "
+            y1 "," x2 " "
+            y1 "," x1)]]]]))
+
+(comment
+  (def c (teet.environment/config-value :road-registry))
+  (def t "ms:n_truup")
+  (def a (gml-area [680129.826,6497718.11221264] [684216.75673899,6501718.11221264]))
+
+  (def culverts (road-registry-objects c t a)))

--- a/app/backend/src/clj/teet/db_api/db_api_handlers.clj
+++ b/app/backend/src/clj/teet/db_api/db_api_handlers.clj
@@ -46,6 +46,7 @@
             teet.asset.asset-queries
             teet.asset.asset-commands
             teet.integration.vektorio.vektorio-queries
+            teet.geo.geo-queries
 
             [teet.log :as log]
             [teet.auth.jwt-token :as jwt-token]

--- a/app/backend/src/clj/teet/db_api/db_api_ion.clj
+++ b/app/backend/src/clj/teet/db_api/db_api_ion.clj
@@ -11,7 +11,8 @@
             [teet.log :as log]
             [tara.routes :as tara-routes]
             [tara.endpoint :as tara-endpoint]
-            [teet.login.login-commands :as login-commands]))
+            [teet.login.login-commands :as login-commands]
+            [teet.util.cache :refer [cached]]))
 
 (log/enable-ion-cast-appender!)
 (some-> (ion/get-env) environment/init-ion-config!)
@@ -33,19 +34,6 @@
                              :store cookie-store})
       cookies/wrap-cookies
       wrap-exception-alert))
-
-(defn cached
-  "Return function to get deferred value. Succesfully created
-  value is cached and returned with subsequent calls.
-
-  If value-fn throws exception when creating value, it isn't cached.
-  Use this instead of delay if value-fn can have intermittent failures."
-  [value-fn]
-  (let [val (atom nil)]
-    (fn []
-      (if-let [v @val]
-        v
-        (swap! val (fn [_] (value-fn)))))))
 
 (defn ring->ion [handler]
   (-> handler wrap-middleware apigw/ionize))

--- a/app/backend/src/clj/teet/geo/geo_queries.clj
+++ b/app/backend/src/clj/teet/geo/geo_queries.clj
@@ -1,20 +1,37 @@
 (ns teet.geo.geo-queries
   "Queries that serve data from PostGIS functions."
   (:require [teet.db-api.core :refer [defquery]]
-            [jeesql.core :refer [defqueries]]))
+            [jeesql.core :refer [defqueries]]
+            [teet.util.coerce :refer [->long]]
+            [datomic.client.api :as d]))
 
 (defqueries "teet/geo/geo_queries.sql")
+
+(defn ->ids [ids]
+  (into-array Long (mapv ->long ids)))
+
+(defn- response [type body]
+  ^{:format :raw}
+  {:status 200
+   :headers {"Content-Type" (case type
+                              :geojson "application/geojson"
+                              :mvt "application/octet-stream")}
+   :body body})
 
 (defquery :geo/entity-pins
   {:doc "Get pins for entity center points"
    :context {pg :pg}
-   :args {type :type}
+   :args {:keys [ids type]}
    :project-id nil
    :authorization {}}
-  ^{:format :raw}
-  {:status 200
-   :headers {"Content-Type" "application/json"}
-   :body (geojson-entity-pins pg {:type type})})
+  (response
+   :geojson
+   (cond
+     type
+     (geojson-entity-pins-for-type pg {:type type})
+
+     ids
+     (geojson-entity-pins-for-ids pg {:ids (->ids ids)}))))
 
 (defquery :geo/entities
   {:doc "Return entity geometries for given entities"
@@ -22,12 +39,11 @@
    :args {ids :ids}
    :project-id nil
    :authorization {}}
-  ^{:format :raw}
-  {:status 200
-   :headers {"Content-Type" "application/json"}
-   :body (geojson-entities
-          pg
-          {:ids (into-array Long (mapv #(Long/parseLong %) ids))})})
+  (response
+   :geojson
+   (geojson-entities
+    pg
+    {:ids (->ids ids)})))
 
 (defquery :geo/mvt
   {:doc "Get tile layer MVT"
@@ -35,9 +51,38 @@
    :args {:keys [type xmin ymin xmax ymax]}
    :project-id nil
    :authorization {}}
-  ^{:format :raw}
-  {:status 200
-   :headers {"Content-Type" "application/octet-stream"}
-   :body (mvt-entities pg {:type type
-                           :xmin xmin :ymin ymin
-                           :xmax xmax :ymax ymax})})
+  (response
+   :mvt
+   (mvt-entities pg {:type type
+                     :xmin xmin :ymin ymin
+                     :xmax xmax :ymax ymax})))
+
+(defquery :geo/project-related-restrictions
+  {:doc "Get project related restrictions as GeoJSON."
+   :context {:keys [db pg]}
+   :args {id :db/id}
+   :project-id id
+   :authorization {:project/read-info {}}}
+  (response
+   :geojson
+   (let [ids (mapv first
+                   (d/q '[:find ?rr
+                          :where [?p :thk.project/related-restrictions ?rr]
+                          :in $ ?p]
+                        db id))]
+     (geojson-features-by-id pg {:ids (into-array String ids)}))))
+
+(defquery :geo/project-related-cadastral-units
+  {:doc "Get project related cadastral units as GeoJSON."
+   :context {:keys [db pg]}
+   :args {id :db/id}
+   :project-id id
+   :authorization {:project/read-info {}}}
+  (response
+   :geojson
+   (let [ids (mapv first
+                   (d/q '[:find ?cu
+                          :where [?p :thk.project/related-cadastral-units ?cu]
+                          :in $ ?p]
+                        db id))]
+     (geojson-features-by-id pg {:ids (into-array String ids)}))))

--- a/app/backend/src/clj/teet/geo/geo_queries.clj
+++ b/app/backend/src/clj/teet/geo/geo_queries.clj
@@ -1,0 +1,43 @@
+(ns teet.geo.geo-queries
+  "Queries that serve data from PostGIS functions."
+  (:require [teet.db-api.core :refer [defquery]]
+            [jeesql.core :refer [defqueries]]))
+
+(defqueries "teet/geo/geo_queries.sql")
+
+(defquery :geo/entity-pins
+  {:doc "Get pins for entity center points"
+   :context {pg :pg}
+   :args {type :type}
+   :project-id nil
+   :authorization {}}
+  ^{:format :raw}
+  {:status 200
+   :headers {"Content-Type" "application/json"}
+   :body (geojson-entity-pins pg {:type type})})
+
+(defquery :geo/entities
+  {:doc "Return entity geometries for given entities"
+   :context {pg :pg}
+   :args {ids :ids}
+   :project-id nil
+   :authorization {}}
+  ^{:format :raw}
+  {:status 200
+   :headers {"Content-Type" "application/json"}
+   :body (geojson-entities
+          pg
+          {:ids (into-array Long (mapv #(Long/parseLong %) ids))})})
+
+(defquery :geo/mvt
+  {:doc "Get tile layer MVT"
+   :context {pg :pg}
+   :args {:keys [type xmin ymin xmax ymax]}
+   :project-id nil
+   :authorization {}}
+  ^{:format :raw}
+  {:status 200
+   :headers {"Content-Type" "application/octet-stream"}
+   :body (mvt-entities pg {:type type
+                           :xmin xmin :ymin ymin
+                           :xmax xmax :ymax ymax})})

--- a/app/backend/src/clj/teet/geo/geo_queries.sql
+++ b/app/backend/src/clj/teet/geo/geo_queries.sql
@@ -1,0 +1,11 @@
+-- name: geojson-entity-pins
+-- single?: true
+SELECT teet.geojson_entity_pins(:type::entity_type);
+
+-- name: geojson-entities
+-- single?: true
+SELECT teet.geojson_entities(:ids::bigint[]);
+
+-- name: mvt-entities
+-- single?: true
+SELECT teet.mvt_entities(:type::entity_type, :xmin::NUMERIC, :ymin::NUMERIC, :xmax::NUMERIC, :ymax::NUMERIC);

--- a/app/backend/src/clj/teet/geo/geo_queries.sql
+++ b/app/backend/src/clj/teet/geo/geo_queries.sql
@@ -1,6 +1,10 @@
--- name: geojson-entity-pins
+-- name: geojson-entity-pins-for-type
 -- single?: true
 SELECT teet.geojson_entity_pins(:type::entity_type);
+
+-- name: geojson-entity-pins-for-ids
+-- single?: true
+SELECT teet.geojson_entity_pins(:ids::bigint[]);
 
 -- name: geojson-entities
 -- single?: true
@@ -9,3 +13,7 @@ SELECT teet.geojson_entities(:ids::bigint[]);
 -- name: mvt-entities
 -- single?: true
 SELECT teet.mvt_entities(:type::entity_type, :xmin::NUMERIC, :ymin::NUMERIC, :xmax::NUMERIC, :ymax::NUMERIC);
+
+-- name: geojson-features-by-id
+-- single?: true
+SELECT teet.geojson_features_by_id(:ids::TEXT[]);

--- a/app/backend/src/clj/teet/notification/notification_sender.clj
+++ b/app/backend/src/clj/teet/notification/notification_sender.clj
@@ -10,6 +10,8 @@
             [clojure.string :as str]
             [teet.localization :refer [with-language tr-enum]]))
 
+;; FIXME: NOT USED ANYWHERE... delete this ns
+
 (def ^:private email (delay (aws/client {:api :email})))
 
 (defn- send-email* [from to subject body]

--- a/app/backend/src/clj/teet/project/project_geometry.clj
+++ b/app/backend/src/clj/teet/project/project_geometry.clj
@@ -1,54 +1,42 @@
 (ns teet.project.project-geometry
   "Code for working with project geometries stored in PostgreSQL.
   Provides functions for calling the PostgREST API."
-  (:require [org.httpkit.client :as http]
-            [teet.auth.jwt-token :as jwt-token]
-            [clojure.string :as str]
-            [cheshire.core :as cheshire]
-            [teet.road.road-query :as road-query]
+  (:require [teet.road.road-query :as road-query]
             [teet.util.geo :as geo]
-            [teet.integration.integration-id :as integration-id]))
+            [teet.integration.integration-id :as integration-id]
+            [teet.log :as log]
+            [jeesql.core :refer [defqueries]]
+            [teet.environment :as environment]))
 
-(defn- valid-api-info? [{:keys [api-url api-secret]}]
-  (and (not (str/blank? api-url))
-       (not (str/blank? api-secret))))
+(defqueries "teet/project/project_geometry.sql")
 
 (defn update-project-geometries!
   "Update project geometries in PostgreSQL.
   Calls store_entity_info in PostgREST API."
-  [{:keys [api-url api-secret wfs-url] :as api} projects]
-  {:pre [(valid-api-info? api)]}
-  (let [road-part-cache (atom {})
-        request-body (for [{id :integration/id
-                            :thk.project/keys [project-name name road-nr carriageway
-                                               start-m end-m
-                                               custom-start-m custom-end-m]}
-                           projects
-                           :when (and id
-                                      (integer? (or custom-start-m start-m))
-                                      (integer? (or custom-end-m end-m))
-                                      (integer? road-nr)
-                                      (integer? carriageway))
-                           :let [geometry (road-query/fetch-road-geometry {:wfs-url wfs-url
-                                                                           :cache-atom road-part-cache}
-                                                                          road-nr carriageway
-                                                                          (or custom-start-m start-m)
-                                                                          (or custom-end-m end-m))]]
-                       {:id (str (integration-id/uuid->number id))
-                        :type "project"
-                        :tooltip (or project-name name)
-                        :geometry_wkt (geo/line-string-to-wkt geometry)})]
-    (when (not-empty request-body)
-      (let [response @(http/post
-                       (str api-url "/rpc/store_entity_info")
-                       {:headers {"Content-Type" "application/json"
-                                  "Authorization"
-                                  (str "Bearer "
-                                       (jwt-token/create-backend-token api-secret))}
-                        :body (cheshire/encode request-body)})]
-        (when-not (= 200 (:status response))
-          (throw (ex-info "Update project geometries failed"
-                          {:expected-response-status 200
-                           :actual-response-status (:status response)
-                           :response response})))))
+  [{:keys [wfs-url]} projects]
+  (let [road-part-cache (atom {})]
+    (doseq [{id :integration/id
+             :thk.project/keys [project-name name road-nr carriageway
+                                start-m end-m
+                                custom-start-m custom-end-m]}
+            projects
+            :when (and id
+                       (integer? (or custom-start-m start-m))
+                       (integer? (or custom-end-m end-m))
+                       (integer? road-nr)
+                       (integer? carriageway))
+            :let [geometry (road-query/fetch-road-geometry
+                            {:wfs-url wfs-url
+                             :cache-atom road-part-cache}
+                            road-nr carriageway
+                            (or custom-start-m start-m)
+                            (or custom-end-m end-m))]]
+      (environment/call-with-pg-connection
+       (fn [conn]
+         (store-entity-info!
+          conn
+          {:id (str (integration-id/uuid->number id))
+           :type "project"
+           :tooltip (or project-name name)
+           :geometry (geo/line-string-to-wkt geometry)}))))
     projects))

--- a/app/backend/src/clj/teet/project/project_geometry.sql
+++ b/app/backend/src/clj/teet/project/project_geometry.sql
@@ -1,0 +1,2 @@
+-- name: store-entity-info!
+SELECT teet.store_entity_info (:id::TEXT, :type::entity_type, :tooltip::TEXT, :geometry::TEXT);

--- a/app/common/src/cljc/teet/util/cache.cljc
+++ b/app/common/src/cljc/teet/util/cache.cljc
@@ -1,0 +1,14 @@
+(ns teet.util.cache)
+
+(defn cached
+  "Return function to get deferred value. Succesfully created
+  value is cached and returned with subsequent calls.
+
+  If value-fn throws exception when creating value, it isn't cached.
+  Use this instead of delay if value-fn can have intermittent failures."
+  [value-fn]
+  (let [val (atom nil)]
+    (fn []
+      (if-let [v @val]
+        v
+        (swap! val (fn [_] (value-fn)))))))

--- a/app/frontend/src/cljs/teet/map/openlayers/mvt.cljs
+++ b/app/frontend/src/cljs/teet/map/openlayers/mvt.cljs
@@ -23,13 +23,15 @@
         extent (.getTileCoordExtent tile-grid coord
                                     (ol-extent/createEmpty))
         [x1 y1 x2 y2] extent]
-    (apply mvt-url
-           url
-           (merge {"xmin" x1 "ymin" y1 "xmax" x2 "ymax" y2
-                   ;;"r" (.getResolution tile-grid (aget coord 0))
-                   ;;"pr" pixel-ratio
-                   }
-                  parameters))))
+    (if (fn? url)
+      (url {:xmin x1 :ymin y1 :xmax x2 :ymax y2})
+      (apply mvt-url
+             url
+             (merge {"xmin" x1 "ymin" y1 "xmax" x2 "ymax" y2
+                     ;;"r" (.getResolution tile-grid (aget coord 0))
+                     ;;"pr" pixel-ratio
+                     }
+                    parameters)))))
 
 (defn load-tile [tile url]
   ;;(.log js/console "Loading: " url)

--- a/app/frontend/src/cljs/teet/project/project_layers.cljs
+++ b/app/frontend/src/cljs/teet/project/project_layers.cljs
@@ -9,7 +9,8 @@
             [teet.project.project-model :as project-model]
             [clojure.string :as str]
             [reagent.core :as r]
-            [teet.map.map-overlay :as map-overlay]))
+            [teet.map.map-overlay :as map-overlay]
+            [teet.common.common-controller :as common-controller]))
 
 (defn- endpoint [app]
   (get-in app [:config :api-url]))
@@ -126,16 +127,17 @@
           style
           options))
 
-       (map-layers/geojson-layer endpoint
-                                 "geojson_entities"
-                                 {"ids" (str "{" (:integration/id project) "}")}
-                                 style
-                                 (assoc options
-                                        ;; Update start/end labels from source geometry
-                                        ;; once it is loaded
-                                        :on-load (partial update-km-range-label-overlays!
-                                                          start-label end-label
-                                                          set-overlays!))))}))
+       (map-layers/geojson-layer
+        {:url (common-controller/query-url :geo/entities {:ids [(:integration/id project)]})}
+        "geojson_entities"
+        nil
+        style
+        (assoc options
+               ;; Update start/end labels from source geometry
+               ;; once it is loaded
+               :on-load (partial update-km-range-label-overlays!
+                                 start-label end-label
+                                 set-overlays!))))}))
 
 (defn setup-restriction-candidates [{{:keys [query]} :app
                                      {:keys [setup-step

--- a/app/frontend/src/cljs/teet/project/project_layers.cljs
+++ b/app/frontend/src/cljs/teet/project/project_layers.cljs
@@ -167,26 +167,25 @@
                                       {:opacity 1})})))
 
 (defn related-restrictions [{{query :query :as app} :app
-                             {restrictions :thk.project/related-restrictions} :project}]
-  (when (and restrictions (not (or (:configure query) (= (:tab query) "land"))))
+                             project :project}]
+  (when (not (or (:configure query) (= (:tab query) "land")))
     {:related-restrictions
-     (map-layers/geojson-layer (endpoint app)
-                               "geojson_features_by_id"
-                               {"ids" restrictions}
+     (map-layers/geojson-layer {:url (common-controller/query-url :geo/project-related-restrictions
+                                                                  {:db/id (:db/id project)})}
+                               "geojson_features_by_id" nil
                                map-features/project-related-restriction-style
-                               {:post? true})}))
+                               {})}))
 
 (defn related-cadastral-units [{{query :query :as app} :app
-                                {cadastral-units :thk.project/related-cadastral-units
-                                 filtered-units :thk.project/filtered-cadastral-units} :project}]
-  (when (and cadastral-units (not (:configure query)))
-    (let [units (or filtered-units cadastral-units)]
-      {:related-cadastral-units
-       (map-layers/geojson-layer (endpoint app)
-                                 "geojson_features_by_id"
-                                 {"ids" units}
-                                 map-features/cadastral-unit-style
-                                 {:post? true})})))
+                                {project-id :db/id} :project}]
+  (when (not (:configure query))
+    {:related-cadastral-units
+     (map-layers/geojson-layer
+      {:url (common-controller/query-url :geo/project-related-cadastral-units
+                                         {:db/id project-id})}
+      "geojson_features_by_id" nil
+      map-features/cadastral-unit-style
+      {})}))
 
 (defn- ags-on-select [e! {:map/keys [teet-id]}]
   (e! (map-controller/->FetchOverlayForEntityFeature [:route :project :overlays] teet-id)))

--- a/app/frontend/src/cljs/teet/projects/projects_view.cljs
+++ b/app/frontend/src/cljs/teet/projects/projects_view.cljs
@@ -21,7 +21,8 @@
             [teet.ui.table :as table]
             [teet.ui.typography :as typography]
             [teet.ui.util :as util :refer [mapc]]
-            [teet.user.user-model :as user-model]))
+            [teet.user.user-model :as user-model]
+            [teet.common.common-controller :as common-controller]))
 
 (defmethod search-interface/format-search-result :project
   [{:thk.project/keys [id] :as project}]
@@ -157,18 +158,20 @@
                (when-not (str/blank? search-term)
                  ;; Showing search results, only fetch those
                  {:search-results
-                  (map-layers/geojson-layer api-url
-                                            "geojson_entities"
-                                            {"ids" (str "{" (str/join "," search-results) "}")}
-                                            map-features/project-line-style
-                                            {:max-resolution map-layers/project-pin-resolution-threshold})
+                  (map-layers/geojson-layer
+                   {:url (common-controller/query-url :geo/entities
+                                                      {:ids search-results})}
+                   "geojson_entities" nil
+                   map-features/project-line-style
+                   {:max-resolution map-layers/project-pin-resolution-threshold})
                   :search-result-pins
-                  (map-layers/geojson-layer api-url
-                                            "geojson_entity_pins"
-                                            {"ids" (str "{" (str/join "," search-results) "}")}
-                                            map-features/project-pin-style
-                                            {:min-resolution map-layers/project-pin-resolution-threshold
-                                             :fit-on-load? true})}))}
+                  (map-layers/geojson-layer
+                   {:url (common-controller/query-url :geo/entity-pins
+                                                      {:ids search-results})}
+                   "geojson_entity_pins" nil
+                   map-features/project-pin-style
+                   {:min-resolution map-layers/project-pin-resolution-threshold
+                    :fit-on-load? true})}))}
      (:map app)]))
 
 (defn projects-list-page [e! app projects]


### PR DESCRIPTION
This is a Work In Progress... do not merge, it needs infrastructure changes to enable the direct connection from compute group nodes.

For discussion an planning.

- New way to get pg connection from environment
- Add pg connection to query/command context with automatic cleanup
- Add geo queries for GeoJSON and MVT endpoints
- Use direct calls to update project geometries


To decide: 
- datasource import also uses the API, do we want to change that to direct JDBC as well?