### PR TITLE
TEET-1676 Initial implementation: Adding materials or products to assets (cost items) 

### DIFF
--- a/app/backend/dev-src/user.clj
+++ b/app/backend/dev-src/user.clj
@@ -57,6 +57,12 @@
   (d/transact (environment/datomic-connection)
               {:tx-data (into [] maps)}))
 
+(defn atx
+  "Transact given maps to asset db"
+  [& maps]
+  (d/transact (asset-connection)
+              {:xt-data (into [] maps)}))
+
 (def mock-users tu/mock-users)
 
 (def manager-uid tu/manager-id)

--- a/app/backend/resources/asset-base-schema.edn
+++ b/app/backend/resources/asset-base-schema.edn
@@ -285,4 +285,10 @@ For example N40-SLD-1 for the first asset in feature class whose OID prefix is S
            :db/valueType :db.type/ref
            :db/cardinality :db.cardinality/many
            :db/doc "The feature groups this material belongs to."}
-          {:db/ident :asset-schema.type/material :db/doc "Material type"}]]}]
+          {:db/ident :asset-schema.type/material :db/doc "Material type"}]]}
+ {:db/ident :migration/component-materials
+  :txes [[{:db/ident :component/materials
+           :db/valueType :db.type/ref
+           :db/cardinality :db.cardinality/many
+           :db/isComponent true
+           :db/doc "The materials for the component"}]]}]

--- a/app/backend/resources/asset-base-schema.edn
+++ b/app/backend/resources/asset-base-schema.edn
@@ -291,4 +291,8 @@ For example N40-SLD-1 for the first asset in feature class whose OID prefix is S
            :db/valueType :db.type/ref
            :db/cardinality :db.cardinality/many
            :db/isComponent true
-           :db/doc "The materials for the component"}]]}]
+           :db/doc "The materials for the component"}
+          {:db/ident :material/type
+           :db/valueType :db.type/ref
+           :db/cardinality :db.cardinality/many
+           :db/doc "The type of a material"}]]}]

--- a/app/backend/resources/asset-base-schema.edn
+++ b/app/backend/resources/asset-base-schema.edn
@@ -294,5 +294,5 @@ For example N40-SLD-1 for the first asset in feature class whose OID prefix is S
            :db/doc "The materials for the component"}
           {:db/ident :material/type
            :db/valueType :db.type/ref
-           :db/cardinality :db.cardinality/many
+           :db/cardinality :db.cardinality/one
            :db/doc "The type of a material"}]]}]

--- a/app/backend/resources/asset-schema.edn
+++ b/app/backend/resources/asset-schema.edn
@@ -1,5 +1,5 @@
 [{:db/id "datomic.tx",
-  :tx/schema-imported-at #inst "2021-05-26T07:52:56.508-00:00"}
+  :tx/schema-imported-at #inst "2021-05-27T13:23:06.982-00:00"}
  {:db/id ":fgroup/carriageway",
   :db/ident :fgroup/carriageway,
   :asset-schema/type :asset-schema.type/fgroup,
@@ -4204,11 +4204,50 @@
   :asset-schema/type :asset-schema.type/enum,
   :asset-schema/label ["Heakskiidetud" "Approved"],
   :enum/attribute ":common/status"}
+ {:db/id ":item/artificalrock",
+  :db/ident :item/artificalrock,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["tehiskivim" "artificial rock"],
+  :enum/attribute ":crushedstone/stonetype"}
  {:db/id ":item/asdesigned",
   :db/ident :item/asdesigned,
   :asset-schema/type :asset-schema.type/enum,
   :asset-schema/label ["Projekteeritud" "As-designed"],
   :enum/attribute ":common/status"}
+ {:db/id ":item/asphalttypedenseasphaltacsurf",
+  :db/ident :item/asphalttypedenseasphaltacsurf,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label
+  ["Tihe asfaltbetoon (AC Surf)" "Dense asphalt (AC Surf)"],
+  :enum/attribute ":asphalt/asphalttype"}
+ {:db/id ":item/asphalttypelightasphaltkab",
+  :db/ident :item/asphalttypelightasphaltkab,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["Kergasfaltbetoon (KAB)" "Light asphalt (KAB)"],
+  :enum/attribute ":asphalt/asphalttype"}
+ {:db/id ":item/asphalttypepermeableasphaltpa",
+  :db/ident :item/asphalttypepermeableasphaltpa,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label
+  ["Dreenasfaltbetoon (PA)" "Permeable asphalt (PA)"],
+  :enum/attribute ":asphalt/asphalttype"}
+ {:db/id ":item/asphalttypeporousasphaltacbase",
+  :db/ident :item/asphalttypeporousasphaltacbase,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label
+  ["Poorne asfaltbetoon (AC Base)" "Porous asphalt (AC Base)"],
+  :enum/attribute ":asphalt/asphalttype"}
+ {:db/id ":item/asphalttypestonemasticsasphalt",
+  :db/ident :item/asphalttypestonemasticsasphalt,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label
+  ["Killustikmastiksasfalt (SMA)" "Stone mastics asphalt"],
+  :enum/attribute ":asphalt/asphalttype"}
+ {:db/id ":item/asphalttypevas",
+  :db/ident :item/asphalttypevas,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["Valuasfalt (VAS)" "(VAS)"],
+  :enum/attribute ":asphalt/asphalttype"}
  {:db/id ":item/bcl_h1",
   :db/ident :item/bcl_h1,
   :asset-schema/type :asset-schema.type/enum,
@@ -4376,6 +4415,26 @@
   :asset-schema/type :asset-schema.type/enum,
   :asset-schema/label ["Puit" "Timber"],
   :enum/attribute ":column/columnmaterial"}
+ {:db/id ":item/concreteclassC25",
+  :db/ident :item/concreteclassC25,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["C25" "C25"],
+  :enum/attribute ":concrete/concreteclass"}
+ {:db/id ":item/concreteclassC35",
+  :db/ident :item/concreteclassC35,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["C35" "C35"],
+  :enum/attribute ":concrete/concreteclass"}
+ {:db/id ":item/concreteclassC45",
+  :db/ident :item/concreteclassC45,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["C45" "C45"],
+  :enum/attribute ":concrete/concreteclass"}
+ {:db/id ":item/concreteclassC55",
+  :db/ident :item/concreteclassC55,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["C55" "C55"],
+  :enum/attribute ":concrete/concreteclass"}
  {:db/id ":item/created",
   :db/ident :item/created,
   :asset-schema/type :asset-schema.type/enum,
@@ -4423,6 +4482,11 @@
   ["Elastse täitega deformatsioonivuuk"
    "flexible plug expansion joint"],
   :enum/attribute ":expansionjoint/expansionjointtype"}
+ {:db/id ":item/ingeousrouck",
+  :db/ident :item/ingeousrouck,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["tardkivim" "igneous rock"],
+  :enum/attribute ":crushedstone/stonetype"}
  {:db/id ":item/inuse",
   :db/ident :item/inuse,
   :asset-schema/type :asset-schema.type/enum,
@@ -4501,6 +4565,11 @@
   :asset-schema/type :asset-schema.type/enum,
   :asset-schema/label ["Lammutatud" "Demolished"],
   :enum/attribute ":common/status"}
+ {:db/id ":item/sedimentaryrock",
+  :db/ident :item/sedimentaryrock,
+  :asset-schema/type :asset-schema.type/enum,
+  :asset-schema/label ["settekivim" "sedimentary rock"],
+  :enum/attribute ":crushedstone/stonetype"}
  {:db/id ":item/signfoundationfoundationtypeconcretecircular",
   :db/ident :item/signfoundationfoundationtypeconcretecircular,
   :asset-schema/type :asset-schema.type/enum,

--- a/app/backend/src/clj/teet/asset/asset_commands.clj
+++ b/app/backend/src/clj/teet/asset/asset_commands.clj
@@ -81,6 +81,31 @@
               (tempids id)
               id))))
 
+(defcommand :asset/save-material
+  {:doc "Save material for a leaf component."
+   :context {:keys [user db]
+             adb :asset-db}
+   :payload {:keys [project-id parent-id material]}
+   :project-id [:thk.project/id project-id]
+   :authorization {:cost-items/edit-cost-items {}}
+   :pre [(or (string? (:db/id material))
+             (= project-id (asset-db/material-project adb (:db/id material))))
+         ^{:error :boq-is-locked}
+         (boq-unlocked? adb project-id)]}
+  (let [id (:db/id material)
+        {:keys [db-after tempids]}
+        (tx
+         ^{:db :asset}
+         [(list 'teet.asset.asset-tx/save-material
+                parent-id
+                (asset-type-library/form->db
+                 (asset-type-library/rotl-map (asset-db/asset-type-library adb))
+                 material))])]
+    (d/pull db-after [:asset/oid]
+            (if (string? id)
+              (tempids id)
+              id))))
+
 (defn- valid-cost-group-price?
   "We want the price to be
    - non-negative

--- a/app/backend/src/clj/teet/asset/asset_commands.clj
+++ b/app/backend/src/clj/teet/asset/asset_commands.clj
@@ -106,6 +106,20 @@
               (tempids id)
               id))))
 
+(defcommand :asset/delete-material
+  {:doc "Delete a material in an existing component."
+   :context {:keys [user db]
+             adb :asset-db}
+   :payload {project-id :project-id material-id :db/id}
+   :project-id [:thk.project/id project-id]
+   :authorization {:cost-items/delete-cost-items {}}
+   :pre [(= project-id (asset-db/material-project adb material-id))
+         ^{:error :boq-is-locked}
+         (boq-unlocked? adb project-id)]
+   :transact
+   ^{:db :asset}
+   [[:db/retractEntity material-id]]})
+
 (defn- valid-cost-group-price?
   "We want the price to be
    - non-negative

--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -452,6 +452,29 @@
                  (str feature-oid "-")
                  (str feature-oid "."))))))
 
+(defn next-material-oid
+  "Get next OID for a new material in component."
+  [db component-oid]
+  {:pre [(asset-model/component-oid? component-oid)]}
+  (asset-model/material-oid
+   component-oid
+   (inc
+    (reduce (fn [max-num [component-oid]]
+              (let [[_ _ _ _ n] (str/split component-oid #"\-")
+                    num (Long/parseLong n)]
+                (max max-num num)))
+            0
+            (d/q '[:find ?oid
+                   :where
+                   [_ :asset/oid ?oid]
+                   [(> ?oid ?start)]
+                   [(< ?oid ?end)]
+                   :in $ ?start ?end]
+                 db
+                 ;; Finds all material OIDs for this component
+                 (str component-oid "-")
+                 (str component-oid "."))))))
+
 (defn project-boq-version
   "Fetch the latest BOQ version entity for the given THK project."
   [db thk-project-id]

--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -394,7 +394,7 @@
   "Returns the THK project id for the material."
   [db material-id]
   (let [material (du/entity db material-id)]
-    (when-let [component-id (:component/_materials material)]
+    (when-let [component-id (-> material :component/_materials :db/id)]
       (component-project db component-id))))
 
 (defn item-type

--- a/app/backend/src/clj/teet/asset/asset_queries.clj
+++ b/app/backend/src/clj/teet/asset/asset_queries.clj
@@ -117,9 +117,14 @@
                       ;; Always pull the full asset even when focusing on a
                       ;; specific subcomponent.
                       ;; PENDING: what if there are thousands?
-                      (if (asset-model/component-oid? cost-item)
-                        (asset-model/component-asset-oid cost-item)
-                        cost-item))})))))
+                      (cond (asset-model/component-oid? cost-item)
+                            (asset-model/component-asset-oid cost-item)
+
+                            (asset-model/material-oid? cost-item)
+                            (asset-model/material-asset-oid cost-item)
+
+                            :else
+                            cost-item))})))))
 
 (s/def :boq-export/version integer?)
 (s/def :boq-export/unit-prices? boolean?)

--- a/app/backend/src/clj/teet/asset/asset_tx.clj
+++ b/app/backend/src/clj/teet/asset/asset_tx.clj
@@ -57,7 +57,10 @@
     [[:db/add [:asset/oid parent-oid]
       :component/materials
       (:db/id material)]
-     (cu/without-nils material)]))
+     (cu/without-nils
+      (assoc material
+             :asset/oid
+             (asset-db/next-material-oid db parent-oid)))]))
 
 (defn lock
   "Create new lock for project BOQ."

--- a/app/backend/src/clj/teet/asset/asset_tx.clj
+++ b/app/backend/src/clj/teet/asset/asset_tx.clj
@@ -41,6 +41,24 @@
        (cu/without-nils
         (assoc component :asset/oid component-oid))])))
 
+(defn save-material
+  "Create or update component.
+  Creates new OID for new components based on parent asset."
+  [db parent-oid {id :db/id :as material}]
+  (when-not (asset-db/leaf-component? db [:asset/oid parent-oid])
+    (throw (ex-info "Not a leaf component OID"
+                    {:parent-oid parent-oid})))
+  ;; TODO: spec
+  (when (not (:material/type material))
+    (throw (ex-info "No material type"
+                    {:parent-oid parent-oid})))
+  (if (number? id)
+    (du/modify-entity-retract-nils db material)
+    [[:db/add [:asset/oid parent-oid]
+      :component/materials
+      (:db/id material)]
+     (cu/without-nils material)]))
+
 (defn lock
   "Create new lock for project BOQ."
   [db {:boq-version/keys [project type] :as lock}]

--- a/app/build-tools/src/teet/asset_schema.clj
+++ b/app/build-tools/src/teet/asset_schema.clj
@@ -353,7 +353,7 @@
                       attr-name (get-in attrs-by-name [(:property item) :name])
                       ctype-fclass-or-material (or (every? ctypes-by-name (:ctype attr))
                                                    (get fclass-by-name (:ctype attr))
-                                                   (get material-by-name (:ctype attr)))
+                                                   (every? material-by-name (:ctype attr)))
                       all-exist? (and attr ctype-fclass-or-material
                                       (:name item)
                                       (exists? (:property item)))]

--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -55,7 +55,7 @@
  :asset
  {:unlock-contract-boq-warning
   "The Cost Item list is in the Contract phase, are you sure that you want to change it, and are you aware that you need to change the budget and inform the management",
-  :add-material nil,
+  :add-material "Add material",
   :totals-table
   {:properties "Cost grouping",
    :project-total "Total {total} EUR",
@@ -93,6 +93,7 @@
   :manager {:link "Assets", :result-count "{count} features"},
   :components {:label "Components"},
   :back-to-cost-item "< Back to {name}",
+  :materials {:label "Materials"},
   :location
   {:hide-map "Hide map",
    :no-road-found-for-points "No road found for points",
@@ -223,6 +224,8 @@
  :contract
  {:no-targets-for-contract
   "Contract integration failed and this contract doesn't have any valid targets. Contact administration for a bug report",
+  :partner-information-text
+  "Please select or add new companies, subcontractors or persons from the left menu.",
   :thk.contract.status/deadline-approaching "Deadline approaching",
   :company-search-placeholder "Enter company name or business id",
   :related-contracts "RELATED CONTRACTS",

--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -1,8 +1,8 @@
 {:account
  {:account-edited "Account information edited.",
   :logout "Logout",
-  :my-details "MY DETAILS",
   :my-account "My account",
+  :my-details "MY DETAILS",
   :save-information "Save information"},
  :activity
  {:note-all-tasks-need-to-be-completed
@@ -12,12 +12,12 @@
   :waiting-for-submission "Results have not yet been submitted"},
  :activity-approval
  {:activity.status/archived "Archive this activity",
-  :submit-for-approval "Submit activity for approval",
   :activity.status/canceled "Cancel this activity",
   :activity.status/completed "Approve this activity",
   :approve-activity-confirm
   "Activity status will be set to Completed.",
-  :reject-activity-confirm "Activity status will be updated."},
+  :reject-activity-confirm "Activity status will be updated.",
+  :submit-for-approval "Submit activity for approval"},
  :admin
  {:create-user "Add user",
   :no-current-permissions "No current permissions",
@@ -55,6 +55,7 @@
  :asset
  {:unlock-contract-boq-warning
   "The Cost Item list is in the Contract phase, are you sure that you want to change it, and are you aware that you need to change the budget and inform the management",
+  :add-material nil,
   :totals-table
   {:properties "Cost grouping",
    :project-total "Total {total} EUR",
@@ -68,35 +69,34 @@
   :add-cost-item "Add cost item",
   :export-boq "Export BOQ",
   :validate
-  {:only-whitespace "Field cannot contain only whitespace",
-   :max-value "Maximum allowed value: {max-value}",
-   :min-value "Minimum allowed value: {min-value}",
+  {:decimal-format "Insert decimal value",
    :decimal-precision
    "Number precision too large. Maximum allowed is {precision}.",
    :integer-format "Insert integer value",
-   :decimal-format "Insert decimal value",
+   :max-length "Text too long, insert at most {max-length} characters",
+   :max-value "Maximum allowed value: {max-value}",
    :min-length
    "Text too short, insert at least {min-length} characters",
-   :max-length
-   "Text too long, insert at most {max-length} characters"},
+   :min-value "Minimum allowed value: {min-value}",
+   :only-whitespace "Field cannot contain only whitespace"},
   :unofficial-version "Unofficial",
   :no-matching-feature-classes "No matching feature classes.",
   :add-component "Add component",
   :unlock-tender-boq-warning
   "The Cost Item list is in the procurement, are you sure that you want to change it, and are you aware that you need to change the date of the procurement and inform the tenders.",
   :cost-item-saved "Cost item saved",
-  :page {:cost-items-totals "Totals", :cost-items "Assets"},
+  :page {:cost-items "Assets", :cost-items-totals "Totals"},
   :feature-group-and-class-placeholder
   "Search feature group or class...",
   :export-boq-filename "THK-{project}-BOQ-{version}.xlsx",
   :save-boq-version "Save BOQ version",
-  :manager {:link "Assets"},
+  :manager {:link "Assets", :result-count "{count} features"},
   :components {:label "Components"},
   :back-to-cost-item "< Back to {name}",
   :location
-  {:show-map "Show map",
-   :hide-map "Hide map",
-   :no-road-found-for-points "No road found for points"},
+  {:hide-map "Hide map",
+   :no-road-found-for-points "No road found for points",
+   :show-map "Show map"},
   :confirm-unlock-for-edits "Yes, unlock",
   :type-library
   {:description "Description",
@@ -111,6 +111,7 @@
    :fgroup "Asset Features",
    :header "Road Object Type Library (ROTL)",
    :common-ctype "Common properties",
+   :product "Products",
    :link "ROTL",
    :label "Label",
    :values "Values",
@@ -122,10 +123,10 @@
    :component-inherits-location
    "Component inherits location from parent"},
   :field-group
-  {:location "Location",
+  {:common "Common",
    :cost-grouping "Cost grouping",
-   :common "Common",
-   :details "Details"},
+   :details "Details",
+   :location "Location"},
   :unlock-for-edits "Unlock for edits"},
  :buttons
  {:confirm "Confirm",
@@ -145,10 +146,10 @@
   :copy-to-clipboard "Copy all text",
   :upload "Upload"},
  :cadastral-group
- {"Avalik-õiguslik omand" "Public property",
+ {"" "Undefined",
+  "Avalik-õiguslik omand" "Public property",
   "Eraomand" "Private property",
   "Kiinistamata eraomand" "Unregistered private property",
-  "" "Undefined",
   "Munitsipaalomand" "Municipal property",
   "Omand väljaselgitamisel" "Property on identification",
   "Riigiomand" "State owned",
@@ -223,31 +224,62 @@
  {:no-targets-for-contract
   "Contract integration failed and this contract doesn't have any valid targets. Contact administration for a bug report",
   :thk.contract.status/deadline-approaching "Deadline approaching",
+  :company-search-placeholder "Enter company name or business id",
   :related-contracts "RELATED CONTRACTS",
   :thk.contract/type "Type",
   :contract-information-heading "Contract information",
   :thk.contract.status/warranty "Warranty",
   :thk.contract/warranty-end-date "Warranty end date",
   :thk.contract.status/deadline-overdue "Deadline overdue",
+  :add-company-not-in-teet "Add a company not in TEET",
   :contract-information "Contract information",
   :contract-save-success "Contract saved",
+  :add-company "Add company",
   :status "Status",
   :table-heading
-  {:project "Project",
+  {:activity "Activity",
+   :project "Project",
    :project-manager "Project manager",
-   :activity "Activity",
    :task "Task"},
   :contract-related-entities "Contract related entities",
+  :no-companies-matching-search "No companies found matching search",
   :partners-listing "Partners listing",
   :thk.contract.status/signed "Signed",
   :partner-information "Partner information",
   :thk.contract.status/completed "Completed",
+  :company-search-label "Company search",
   :contracts-listing "Contract listing",
   :edit-contract "Contract information",
   :thk.contract.status/in-progress "In progress"},
  :contracts
- {:state-procurement-link "Procurement no.",
+ {:contracts-list
+  {:collapse-all "Collapse all",
+   :expand-all "Expand all",
+   :result "Result",
+   :results "results",
+   :view "View"},
   :external-link "Contract no.",
+  :filters
+  {:hide-filters "Hide filters",
+   :inputs
+   {:contract-number "Contract number",
+    :project-name "Object name",
+    :ta/region "Region",
+    :partner-name "Partner name",
+    :project-manager "TA Project manager",
+    :contract-status "Contract status",
+    :contract-type "Contact type",
+    :contract-name "Procurement name",
+    :procurement-number "Procurement number",
+    :road-number "Road number"},
+   :select-input-placeholder "Select",
+   :show-filters "Show filters"},
+  :quick-filters "Quick filters",
+  :shortcuts
+  {:all-contracts "All contracts",
+   :my-contracts "My contracts",
+   :unassigned "Unassigned"},
+  :state-procurement-link "Procurement no.",
   :thk-procurement-link "THK"},
  :cooperation
  {:response "Response",
@@ -279,29 +311,29 @@
   :add-application-contact "Add contact",
   :third-party-deleted "Involved party deleted",
   :export
-  {:cooperation.application.response-type/opinion
-   {:user-column nil,
-    :content-column nil,
-    :header "OPINIONS",
-    :decision-column nil},
-   :preview "Preview",
-   :cooperation.application.response-type/other
-   {:user-column nil,
-    :header nil,
+  {:cooperation.application.response-type/consent
+   {:content-column nil,
     :decision-column nil,
-    :content-column nil},
-   :seq#-column nil,
+    :header nil,
+    :user-column nil},
    :cooperation.application.response-type/coordination
-   {:user-column nil,
-    :content-column nil,
+   {:content-column nil,
+    :decision-column nil,
     :header nil,
-    :decision-column nil},
-   :title "Involved parties summary table",
-   :cooperation.application.response-type/consent
-   {:user-column nil,
-    :content-column nil,
+    :user-column nil},
+   :cooperation.application.response-type/opinion
+   {:content-column nil,
+    :decision-column nil,
+    :header "OPINIONS",
+    :user-column nil},
+   :cooperation.application.response-type/other
+   {:content-column nil,
+    :decision-column nil,
     :header nil,
-    :decision-column nil}},
+    :user-column nil},
+   :preview "Preview",
+   :seq#-column nil,
+   :title "Involved parties summary table"},
   :newest-application "Newest application",
   :create-opinion-button "Opinion of Competent Authority",
   :application-edited "Application edited succesfully",
@@ -322,14 +354,14 @@
   :waiting-for-opinion "Waiting for opinion",
   :new-third-party-title "Add involved party",
   :error
-  {:response-not-given "Files can be added after response is added",
-   :coordination-task-missing
+  {:coordination-task-missing
    "Coordination task does not exist for the activity.",
    :coordination-task-status-no-upload
    "Coordination task state does not allow file uploading.",
-   :upload-not-allowed "Upload not allowed",
    :response-not-editable
-   "Response has an opinion added and can't be edited."},
+   "Response has an opinion added and can't be edited.",
+   :response-not-given "Files can be added after response is added",
+   :upload-not-allowed "Upload not allowed"},
   :response-of-third-party "Response of involved party",
   :opinion-created "Opinion created successfully",
   :response-created "Response created successfully",
@@ -340,30 +372,31 @@
   :opinion-saved "Opinion saved successfully",
   :new-third-party "Add involved party",
   :results "{count} results"},
+ :countries {:ee "Estonia", :fi "Finland"},
  :dashboard
- {:open "Open",
+ {:activities-and-tasks "Activities and tasks",
   :my-projects "My projects",
-  :notifications "Notifications",
-  :activities-and-tasks "Activities and tasks",
   :no-notifications-for-project
   "You have no notifications related to this project",
+  :notifications "Notifications",
+  :open "Open",
   :title "Dashboard"},
  :data-tab
  {:cadastral-unit-count "Currently showing {count} cadastral units",
   :restriction-count "Currently showing {count} restrictions"},
  :date-range {:error-text "Possible dates: {start} – {end}"},
  :document
- {:deleted-notification "Document deleted successfully",
+ {:comments "Comments",
+  :deleted-notification "Document deleted successfully",
   :file-deleted-notification "File deleted successfully",
   :file-too-large "file is too large",
   :invalid-file-type "file type is not valid",
-  :comments "Comments",
-  :updated "Updated",
-  :new-comment "New comment"},
+  :new-comment "New comment",
+  :updated "Updated"},
  :drag
- {:drop-to-meeting-decision "Attach file to meeting decision",
-  :drop-to-comment "Add images to comment",
+ {:drop-to-comment "Add images to comment",
   :drop-to-meeting-agenda "Attach file to meeting agenda",
+  :drop-to-meeting-decision "Attach file to meeting decision",
   :drop-to-task "Upload files to task",
   :no-drop-zone "No drop zone"},
  :email
@@ -412,6 +445,7 @@
   :task.type/plot-allocation-plan "Plot allocation plan",
   :file.document-group/general "General",
   :task.type/railroad "Railroad",
+  :activity.name/owners-supervision "Owners supervision",
   :document.sub-category/design-requirements "Design requirements",
   :task.group/warranty "Warranty",
   :task.group/design-approval "Design approval",
@@ -488,6 +522,7 @@
   "Laboratory Certificate",
   :task.type/cost-list "Bill of Quantities",
   :task.type/eia-pre-assessment "EIA pre-assessment",
+  :activity.name/road-safety-audit "Road safety audit",
   :task.type/owners-supervision "Owners' supervision",
   :task.group/study "Studies",
   :thk.contract.type/construction-works "Construction works",
@@ -657,15 +692,15 @@
   :task.type/road "Road",
   :cooperation.application.response-type/coordination "Coordination"},
  :environment
- {:info-text
+ {:build-time "Last build happened at",
+  :info-text
   {:dev
    "You are using the development environment of teet. Information saved here may be lost.",
    :prelive
    "You are using the training environment of TEET. From time to time the data in the environment is updated and the manually added data disappears.",
    :test
    "You are using the test environment of TEET. From time to time the data in the environment is updated and the manually added data disappears."},
-  :version "Version",
-  :build-time "Last build happened at"},
+  :version "Version"},
  :error
  {:file-metadata-not-unique
   "Uploading this file with the given metadata would create a duplicate file under the task or duplicate files already exist for this task",
@@ -756,6 +791,7 @@
   :cooperation.contact/id-code "Business reg / personal ID code",
   :file.part/name "Part name",
   :task/group "Task group",
+  :company/business-registry-code "Business registry code",
   :file/part "Part",
   :cooperation.3rd-party/name "Involved party name",
   :file/version "Version",
@@ -784,6 +820,7 @@
   :thk.project/end-km "End km",
   :cooperation.application/response-deadline "Response deadline",
   :thk.project/start-km "Start km",
+  :company/name "Company name",
   :cooperation.response/content "Response content",
   "projectgroup" {"activity" "Activities"},
   :file/original-name "Original filename",
@@ -809,6 +846,7 @@
   "Respondents connection to the land",
   :thk.contract/warranty-period "Warranty period",
   :land-acquisition/pos-number "POS#",
+  :company/country "Country",
   :meeting.agenda/responsible "Responsible person",
   :document/sub-category "Document subtype",
   :location/road-address "Road address",
@@ -843,6 +881,7 @@
   :land-owner-opinion/activity "Activity",
   :file/timestamp "Upload date",
   :cooperation.3rd-party/email "E-mail address",
+  :company/phone-numbers "Company phone number",
   :user/email "Email",
   :land-acquisition/area-to-obtain "Area to obtain",
   :file/sequence-number "#",
@@ -861,6 +900,7 @@
   :meeting/links "Links",
   :activity/name "Activity name",
   :location/start-km "Start km",
+  :company/emails "Company e-mail",
   :estate-compensation/amount "Amount",
   :document/category "Document type",
   :boq-version/type "Update version status",
@@ -892,18 +932,18 @@
   :upload-info "Uploaded {date} by {author}",
   :upload-success "File uploaded successfully",
   :export-files-zip
-  {:email-body
-   "Download from: \n{link}\nThe link is valid for 24 hours.",
-   :activity-button "Email link to files related to the activity ",
-   :task-button "Email link to files related to the task ",
+  {:activity-button "Email link to files related to the activity ",
    :activity-email-subject
    "The export of activity-related documents has ended",
    :activity-success
    "Documents related to the activity are exported. A link to the documents will be emailed to you shortly",
-   :task-success
-   "Documents related to the task are exported. A link to the documents will be emailed to you shortly",
+   :email-body
+   "Download from: \n{link}\nThe link is valid for 24 hours.",
+   :task-button "Email link to files related to the task ",
    :task-email-subject
-   "The export of task-related documents has ended"},
+   "The export of task-related documents has ended",
+   :task-success
+   "Documents related to the task are exported. A link to the documents will be emailed to you shortly"},
   :replace-dialog-title "Upload new version ",
   :edit-info "Last edited {date} by {author}",
   :other-versions "Other versions",
@@ -912,10 +952,10 @@
   :full-name "TEET Full name",
   :switch-to-latest-version "Switch back to latest version",
   :sort-by
-  {:file/type "Sort by file type",
-   :meta/created-at "Sort by date",
-   :file/name "Sort by name",
-   :file/status "Sort by status"},
+  {:file/name "Sort by name",
+   :file/status "Sort by status",
+   :file/type "Sort by file type",
+   :meta/created-at "Sort by date"},
   :replace-dialog-info-text
   "Don't worry we will keep the current version, so you can go back to it if you need to.",
   :version "Version {num}",
@@ -983,9 +1023,9 @@
   :cadastral-filter-label "Cadastral unit number",
   :unit-name-id "Unit name and id",
   :quality
-  {:bad "Bad",
+  {:any "Any",
+   :bad "Bad",
    :good "Good (L-Est)",
-   :any "Any",
    :questionable "Questionable"},
   :filter-label "Filter units",
   :total-excluding-process "Total excluding process fees:",
@@ -1009,12 +1049,12 @@
   :comments "Comments",
   :mortgages "Mortgages",
   :modal-title
-  {:mortgages "Mortgages",
-   :burdens "Burdens",
-   :costs "Acquisition costs",
-   :owners-opinions "Land owners opinions",
+  {:burdens "Burdens",
    :comments "Comments",
-   :files "Files attached to this unit"},
+   :costs "Acquisition costs",
+   :files "Files attached to this unit",
+   :mortgages "Mortgages",
+   :owners-opinions "Land owners opinions"},
   :costs "Acquisition costs",
   :mortgage "Mortgage",
   :owner-opinions "Opinions",
@@ -1032,10 +1072,10 @@
   :choose-activity "Choose an activity",
   :update {:success-message "Opinion successfully edited"},
   :delete
-  {:success-message "Opinion deleted",
-   :cancel-text "No, return back",
+  {:cancel-text "No, return back",
    :confirmation-text
-   "All information will be deleted and cannot be recovered"},
+   "All information will be deleted and cannot be recovered",
+   :success-message "Opinion deleted"},
   :export
   {:units-with-opinions nil,
    :estate-num-name nil,
@@ -1050,24 +1090,26 @@
   :choose-type "Choose a type",
   :edit-opinion "EDIT OPINION"},
  :link
- {:search {:no-results "No results", :placeholder "Link..."},
+ {:land-unit-not-in-project "Not selected in project",
+  :no-units-in-estate-selected "No units selected in the project",
+  :search {:no-results "No results", :placeholder "Link..."},
+  :target-deleted "Deleted by {user} at {at}",
   :type-label
-  {:file "File",
+  {:appendix "Appendix",
    :cadastral-unit "Cadastral unit",
    :estate "Estate",
-   :appendix "Appendix",
-   :task "Task"},
-  :target-deleted "Deleted by {user} at {at}",
-  :land-unit-not-in-project "Not selected in project",
-  :no-units-in-estate-selected "No units selected in the project"},
+   :file "File",
+   :task "Task"}},
  :login
- {:username "Username",
-  :password "Password",
+ {:greetings-text
+  "Road life cycle information management and common data environment TEET",
   :login "Login",
-  :greetings-text
-  "Road life cycle information management and common data environment TEET"},
+  :password "Password",
+  :username "Username"},
  :map
  {:aerial-view "Aerial view",
+  :clear-selections "Clear selections",
+  :display "Map display",
   :layers
   {:no-filters "No filters available",
    :projects "Projects",
@@ -1080,9 +1122,7 @@
    :cadastral-units "Cadastral units",
    :no-layers "No map layers",
    :land-surveys "Land surveys"},
-  :display "Map display",
   :map-layers "Map layers",
-  :clear-selections "Clear selections",
   :select-all "Select all"},
  :meeting
  {:notifications-help
@@ -1188,12 +1228,12 @@
  :page-title {:project-list "{name} project"},
  :people-tab
  {:active "ACTIVE",
-  :managers "Managers",
   :consultants "Consultants",
-  :invite-user "Invite new user to TEET",
-  :other-users "Other users",
   :hide-history "Hide history",
+  :invite-user "Invite new user to TEET",
+  :managers "Managers",
   :no-other-users "No other users",
+  :other-users "Other users",
   :show-history "Show history"},
  :project
  {:add-users "Add users",
@@ -1237,14 +1277,14 @@
   :add-task "Add task",
   :draw-selection
   {:deselect "Deselect areas",
-   :select "Select areas",
-   :link "Draw selection on map"},
+   :link "Draw selection on map",
+   :select "Select areas"},
   :information
-  {:estimated-duration "Estimated duration",
-   :procurement-number "Procurement number",
+  {:carriageway "CW",
+   :estimated-duration "Estimated duration",
    :km-range "Km range",
+   :procurement-number "Procurement number",
    :repair-method "Method",
-   :carriageway "CW",
    :road-number "Road number"},
   :add-tasks "Add tasks",
   :activities "Project activities",
@@ -1256,20 +1296,20 @@
   :activities-tab "Activities"},
  :project-groups {:title "Project groups"},
  :projects
- {:map-view "Map",
-  :filters
+ {:filters
   {:all "All projects",
-   :unassigned-only "Unassigned projects only",
-   :my-projects "My projects"},
-  :title "Projects",
+   :my-projects "My projects",
+   :unassigned-only "Unassigned projects only"},
   :list-view "Project list",
-  :no-activities "No activities"},
+  :map-view "Map",
+  :no-activities "No activities",
+  :title "Projects"},
  :roles
  {:authenticated-guest "Authenticated guest",
-  :guest "Guest",
-  :manager "Project manager",
-  :internal-consultant "Internal consultant",
   :external-consultant "External consultant",
+  :guest "Guest",
+  :internal-consultant "Internal consultant",
+  :manager "Project manager",
   :owner "Owner"},
  :search {:clear-filters "Clear filters", :quick-search "Search"},
  :search-area
@@ -1291,11 +1331,11 @@
   :inclusion-distance-placeholder "Give value to show related areas",
   :component-title "Related features search area"},
  :tab-names
- {:upcoming "Upcoming",
-  :notes "Comments",
+ {:decisions "Decisions",
+  :details "Details",
   :history "History",
-  :decisions "Decisions",
-  :details "Details"},
+  :notes "Comments",
+  :upcoming "Upcoming"},
  :task
  {:task-overview "Task overview",
   :edit-part-modal-title "Edit task part",
@@ -1349,15 +1389,15 @@
  :unit-info {:owners-opinions "Land owners opinions"},
  :unit-modal-page {:add-new-owner-opinion "Add new opinion"},
  :user
- {:unregistered "User",
-  :autocomplete
-  {:no-options "User not found",
-   :loading "Searching users...",
+ {:autocomplete
+  {:loading "Searching users...",
+   :no-options "User not found",
    :placeholder "Type name..."},
-  :role "Role"},
+  :role "Role",
+  :unregistered "User"},
  :validation {:invalid-email "Invalid email address"},
  :warning
- {:version-mismatch
-  "A new version of the application has been deployed. Please refresh the page.",
-  :deploying
-  "A new version of the application is being deployed. Please wait for a few minutes and refresh the page."}}
+ {:deploying
+  "A new version of the application is being deployed. Please wait for a few minutes and refresh the page.",
+  :version-mismatch
+  "A new version of the application has been deployed. Please refresh the page."}}

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -1,8 +1,8 @@
 {:account
  {:account-edited "Konto muudetud",
   :logout "Logout",
-  :my-details "MINU ANDMED",
   :my-account "Minu konto",
+  :my-details "MINU ANDMED",
   :save-information "Salvestan andmed"},
  :activity
  {:note-all-tasks-need-to-be-completed
@@ -12,11 +12,11 @@
   :waiting-for-submission "Tulemusi ei ole veel esitatud"},
  :activity-approval
  {:activity.status/archived "Arhiveerin tegevuse",
-  :submit-for-approval "Esitan tegevuse",
   :activity.status/canceled "Katkestan tegevuse",
   :activity.status/completed "Kinnitan tegevuse",
   :approve-activity-confirm "Tegevuse staatus märgitakse lõpetatuks",
-  :reject-activity-confirm "Tegevuse staatus uuendatakse"},
+  :reject-activity-confirm "Tegevuse staatus uuendatakse",
+  :submit-for-approval "Esitan tegevuse"},
  :admin
  {:create-user "Lisan kasutaja",
   :no-current-permissions "Kehtivad ligipääsud puuduvad",
@@ -54,6 +54,7 @@
  :asset
  {:unlock-contract-boq-warning
   "Kululoend on aktiivses lepingus. Selle muutmine tähendab lepingu muudatust. Kas oled kindel, et soovid avada kululoendi muudatusteks?",
+  :add-material "Lisan materjal",
   :totals-table
   {:properties "Kulude grupeerimine",
    :project-total "Kokku {total} EUR",
@@ -67,34 +68,34 @@
   :add-cost-item "Lisan vara",
   :export-boq "Kululoendi eksport",
   :validate
-  {:only-whitespace "Ainult tühik ei ole lubatud.",
-   :max-value "Lubatud maksimaalne väärtus on {max-value}",
-   :min-value "Lubatud minimaalne väärtus on {min-value}",
+  {:decimal-format "Sisestage kümnendväärtus",
    :decimal-precision
    "Numbri täpsus on liiga suur. Lubatud on {precision} kohta peale punkti.",
    :integer-format "Sisesta täisarv",
-   :decimal-format "Sisestage kümnendväärtus",
+   :max-length
+   "Tekst liiga pikk, sisesta maksimaalselt {max-value} sümbolit",
+   :max-value "Lubatud maksimaalne väärtus on {max-value}",
    :min-length
    "Tekst liiga lühike, sisesta vähemalt {min-length} sümbolit",
-   :max-length
-   "Tekst liiga pikk, sisesta maksimaalselt {max-value} sümbolit"},
+   :min-value "Lubatud minimaalne väärtus on {min-value}",
+   :only-whitespace "Ainult tühik ei ole lubatud."},
   :unofficial-version "Mitteametlik",
   :no-matching-feature-classes "Pole vastavat vara liiki",
   :add-component "Lisan komponendi",
   :unlock-tender-boq-warning
   "Kululoend on hetkel hankes, kas oled kindel , et soovid seda muuta? Hanke kululoendi muutmisel tuleb teavitada pakkujaid ning vajadusel muuta pakkumuste esitamise tähtaega.",
   :cost-item-saved "Vara salvestatud",
-  :page {:cost-items-totals "Summad", :cost-items "Varad"},
+  :page {:cost-items "Varad", :cost-items-totals "Summad"},
   :feature-group-and-class-placeholder "Otsi vara gruppi või liiki",
   :export-boq-filename "THK-{project}-kululoend-{version}.xlsx",
   :save-boq-version "Salvesta kululoendi versioon",
-  :manager {:link "Varad"},
+  :manager {:link "Varad", :result-count "{count} nähtust"},
   :components {:label "Komponendid"},
   :back-to-cost-item "< Tagasi {name}",
   :location
-  {:show-map "Näita kaarti",
-   :hide-map "Peida kaart",
-   :no-road-found-for-points "Punktide jaoks ei leitud teed"},
+  {:hide-map "Peida kaart",
+   :no-road-found-for-points "Punktide jaoks ei leitud teed",
+   :show-map "Näita kaarti"},
   :confirm-unlock-for-edits "Jah, ava",
   :type-library
   {:description "Kirjeldus",
@@ -109,6 +110,7 @@
    :fgroup "Vara grupp",
    :header "Tee olemi tüübiteek (TOTT) ",
    :common-ctype "Ühised omadused",
+   :product "Tooted",
    :link "TOTT",
    :label "Silt",
    :values "Väärtused",
@@ -119,10 +121,10 @@
    :attributes "Tunnused",
    :component-inherits-location "Komponent pärib asukoha vanemalt"},
   :field-group
-  {:location "Asukoht",
+  {:common "Ühine",
    :cost-grouping "Kulude grupeerimine",
-   :common "Ühine",
-   :details "Üksikasjad"},
+   :details "Üksikasjad",
+   :location "Asukoht"},
   :unlock-for-edits "Avage muudatuste tegemiseks"},
  :buttons
  {:confirm "Kinnitan",
@@ -142,10 +144,10 @@
   :copy-to-clipboard "Kopeeri tekst",
   :upload "Laadin üles"},
  :cadastral-group
- {"Avalik-õiguslik omand" "Avalik-õiguslik omand",
+ {"" "Määratlemata",
+  "Avalik-õiguslik omand" "Avalik-õiguslik omand",
   "Eraomand" "Eraomand",
   "Kiinistamata eraomand" "Kinnistamata eraomand",
-  "" "Määratlemata",
   "Munitsipaalomand" "Munitsipaalomand",
   "Omand väljaselgitamisel" "Omand väljaselgitamisel",
   "Riigiomand" "Riigiomand",
@@ -220,31 +222,64 @@
  {:no-targets-for-contract
   "Lepingu integreerimine ei õnnestunud ja sellel lepingul pole kehtivaid eesmärke.\nVeateate saamiseks pöörduge administratsiooni poole",
   :thk.contract.status/deadline-approaching "Tähtaeg läheneb",
+  :company-search-placeholder
+  "Sisesta ettevõtte nimi või äriregistri kood",
   :related-contracts "SEOTUD LEPINGUD",
   :thk.contract/type "Tüüp",
   :contract-information-heading "Lepingu info",
   :thk.contract.status/warranty "Garantii",
   :thk.contract/warranty-end-date "Garantii lõppkuupäev",
   :thk.contract.status/deadline-overdue "Tähtaeg on hilinenud",
+  :add-company-not-in-teet "Lisa uus ettevõtte",
   :contract-information "Lepingu info",
   :contract-save-success "Leping salvestatud",
+  :add-company "Lisa ettevõtte",
   :status "Staatus",
   :table-heading
-  {:project "Projekt",
+  {:activity "Tegevus",
+   :project "Projekt",
    :project-manager "Projektijuht",
-   :activity "Tegevus",
    :task "Ülesanne"},
   :contract-related-entities "Lepinguga seotud üksused",
+  :no-companies-matching-search
+  "Otsingule vastavaid ettevõtteid ei leitud",
   :partners-listing "Partnerite loetelu",
   :thk.contract.status/signed "Allkirjastatud",
   :partner-information "Partnerite info",
   :thk.contract.status/completed "Valmis",
+  :company-search-label "Ettevõtte otsing",
   :contracts-listing "Lepingute loetelu",
   :edit-contract "Lepingu info",
   :thk.contract.status/in-progress "Töös"},
  :contracts
- {:state-procurement-link "Hanke nr.",
+ {:contracts-list
+  {:collapse-all "Ahenda kõik",
+   :expand-all "Laeinda kõik",
+   :result "Tulemus",
+   :results "tulemust",
+   :view "Vaata"},
   :external-link "Lepingu nr.",
+  :filters
+  {:hide-filters "Peida filtrid",
+   :inputs
+   {:contract-number "Lepingu number",
+    :project-name "Objekti nimi",
+    :ta/region "Regioon",
+    :partner-name "Lepingupartneri nimi",
+    :project-manager "TA projektijuht",
+    :contract-status "Lepingu staatus",
+    :contract-type "Lepingu liik",
+    :contract-name "Hanke nimetus",
+    :procurement-number "Hanke number",
+    :road-number "Tee number"},
+   :select-input-placeholder "Vali",
+   :show-filters "Näita filtreid"},
+  :quick-filters "Kiirotsing",
+  :shortcuts
+  {:all-contracts "Kõik lepingud",
+   :my-contracts "Minu lepingud",
+   :unassigned "Määramata lepingud"},
+  :state-procurement-link "Hanke nr.",
   :thk-procurement-link "THK"},
  :cooperation
  {:response "Vastus",
@@ -276,29 +311,29 @@
   :add-application-contact "Lisan kontakti",
   :third-party-deleted "Kaasatud osapool kustutatud",
   :export
-  {:cooperation.application.response-type/opinion
-   {:user-column "Arvamuse esitaja",
-    :content-column "Arvamuse sisu",
-    :header "ARVAMUSED ",
-    :decision-column "Otsus esitatud arvamuse osas"},
-   :preview "Eelvaade",
-   :cooperation.application.response-type/other
-   {:user-column "Esitaja",
-    :header "MUU",
-    :decision-column "Otsus",
-    :content-column "Sisu"},
-   :seq#-column "Jrk nr",
-   :cooperation.application.response-type/coordination
-   {:user-column "Kaasatud kooskõlastaja",
-    :content-column "Kooskõlastuse sisu",
-    :header "KOOSKÕLASTUSED",
-    :decision-column "Otsus esitatud kooskõlastuse osas"},
-   :title "Kaasatud osapoolte koondtabel",
-   :cooperation.application.response-type/consent
-   {:user-column "Nõusoleku esitaja",
-    :content-column "Nõusoleku sisu",
+  {:cooperation.application.response-type/consent
+   {:content-column "Nõusoleku sisu",
+    :decision-column "Otsus esitatud nõusoleku osas",
     :header "NÕUSOLEKUD",
-    :decision-column "Otsus esitatud nõusoleku osas"}},
+    :user-column "Nõusoleku esitaja"},
+   :cooperation.application.response-type/coordination
+   {:content-column "Kooskõlastuse sisu",
+    :decision-column "Otsus esitatud kooskõlastuse osas",
+    :header "KOOSKÕLASTUSED",
+    :user-column "Kaasatud kooskõlastaja"},
+   :cooperation.application.response-type/opinion
+   {:content-column "Arvamuse sisu",
+    :decision-column "Otsus esitatud arvamuse osas",
+    :header "ARVAMUSED ",
+    :user-column "Arvamuse esitaja"},
+   :cooperation.application.response-type/other
+   {:content-column "Sisu",
+    :decision-column "Otsus",
+    :header "MUU",
+    :user-column "Esitaja"},
+   :preview "Eelvaade",
+   :seq#-column "Jrk nr",
+   :title "Kaasatud osapoolte koondtabel"},
   :newest-application "Uusim pöördumine",
   :create-opinion-button "Lisan ametliku seisukoha",
   :application-edited "Taotlus edukalt muutetud",
@@ -319,13 +354,13 @@
   :waiting-for-opinion "Ootab seisukohta",
   :new-third-party-title "Kaasatud osapoole lisamine",
   :error
-  {:response-not-given "Faile saab lisada peale vastuse lisamist",
-   :coordination-task-missing "Tegevusel puudub kooskõlastusülesanne.",
+  {:coordination-task-missing "Tegevusel puudub kooskõlastusülesanne.",
    :coordination-task-status-no-upload
    "Ülesande staatus ei luba failide lisamist.",
-   :upload-not-allowed "Üleslaadimine pole lubatud",
    :response-not-editable
-   "Vastusele on seisukoht lisatud ja vastust ei saa enam muuta. "},
+   "Vastusele on seisukoht lisatud ja vastust ei saa enam muuta. ",
+   :response-not-given "Faile saab lisada peale vastuse lisamist",
+   :upload-not-allowed "Üleslaadimine pole lubatud"},
   :response-of-third-party "Kaasatud osapoole vastus",
   :opinion-created "Seisukoht edukalt loodud",
   :response-created "Vastus edukalt loodud",
@@ -336,30 +371,31 @@
   :opinion-saved "Seisukoht edukalt salvestatud",
   :new-third-party "Lisan kaasatud osapoole",
   :results "{count} tulemust"},
+ :countries {:ee nil, :fi nil},
  :dashboard
- {:open "Avan",
+ {:activities-and-tasks "Tegevused ja ülesanded",
   :my-projects "Minu projektid",
-  :notifications "Teavitused",
-  :activities-and-tasks "Tegevused ja ülesanded",
   :no-notifications-for-project
   "Teil pole selle projektiga seotud teatisi",
+  :notifications "Teavitused",
+  :open "Avan",
   :title "Töölaud"},
  :data-tab
  {:cadastral-unit-count "Praegu kuvatakse {count} katastriüksus(t)",
   :restriction-count "Praegu kuvatakse {count} kitsendus(t)"},
  :date-range {:error-text "Võimalikud kuupäevad: {start} – {end}"},
  :document
- {:deleted-notification "Dokument edukalt kustutatud",
+ {:comments "Märkused",
+  :deleted-notification "Dokument edukalt kustutatud",
   :file-deleted-notification "Fail edukalt kustutatud",
   :file-too-large "Fail on liiga suur",
   :invalid-file-type "Failitüüp ei ole toetatud",
-  :comments "Märkused",
-  :updated "Uuendatud",
-  :new-comment "Uus märkus"},
+  :new-comment "Uus märkus",
+  :updated "Uuendatud"},
  :drag
- {:drop-to-meeting-decision "Lisan koosoleku otsusele faile",
-  :drop-to-comment "Lisan märkusele pilte",
+ {:drop-to-comment "Lisan märkusele pilte",
   :drop-to-meeting-agenda "Lisan päevakavapunktile faile",
+  :drop-to-meeting-decision "Lisan koosoleku otsusele faile",
   :drop-to-task "Lisan ülesandele faile",
   :no-drop-zone "Siia ei saa faile lohistada"},
  :email
@@ -408,6 +444,7 @@
   "Ümberkruntimiskava (krundijaotuskava)",
   :file.document-group/general "Üldosa, seletuskirjad ",
   :task.type/railroad "Raudtee",
+  :activity.name/owners-supervision "Omanike järelevalve",
   :document.sub-category/design-requirements
   "Projekteerimistingimused",
   :task.group/warranty "Garantii",
@@ -485,6 +522,7 @@
   :document.sub-category/laboratory-certificate "Laboriprotokoll",
   :task.type/cost-list "Kululoend",
   :task.type/eia-pre-assessment "Keskkonnamõju eelhinnang",
+  :activity.name/road-safety-audit "Teeohutuse audit",
   :task.type/owners-supervision "Omanikujärelevalve",
   :task.group/study "Uuringud",
   :thk.contract.type/construction-works "Ehitustööd",
@@ -651,15 +689,15 @@
   :task.type/road "Tee",
   :cooperation.application.response-type/coordination "Kooskõlastus"},
  :environment
- {:info-text
+ {:build-time "Viimane versiooniuuendus toimus",
+  :info-text
   {:dev
    "Kasutad TEETu arenduskeskkonda. Aeg-ajalt andmeid keskkonnas kustutatakse.",
    :prelive
    "Kasutad TEETu koolituskeskkonda. Aeg-ajalt andmeid keskkonnas uuendatakse ja vahepeal lisatud kaovad.",
    :test
    "Kasutad TEETu testkeskkonda. Aeg-ajalt andmeid keskkonnas uuendatakse ja vahepeal lisatud kaovad. "},
-  :version "Versioon",
-  :build-time "Viimane versiooniuuendus toimus"},
+  :version "Versioon"},
  :error
  {:file-metadata-not-unique
   "Selle faili üleslaadimine antud metaandmetega tekitaks ülesandesse duplikaat faili või ülesandes on juba duplikaat failid.",
@@ -748,6 +786,7 @@
   :cooperation.contact/id-code "Reg. nr / isikukood",
   :file.part/name "Ülesande osa nimi",
   :task/group "Ülesande grupp",
+  :company/business-registry-code "Äriregistri kood",
   :file/part "Osa",
   :cooperation.3rd-party/name "Kaasatud osapoole nimi",
   :file/version "Versioon",
@@ -777,6 +816,7 @@
   :thk.project/end-km "Lõpp km",
   :cooperation.application/response-deadline "Taotluse tähtaeg",
   :thk.project/start-km "Algus km",
+  :company/name "Ettevõtte nimi",
   :cooperation.response/content "Vastuse sisu",
   "projectgroup" {"activity" "Etapp"},
   :file/original-name "Algupärane failinimi",
@@ -802,6 +842,7 @@
   "Vastaja seotus maaga",
   :thk.contract/warranty-period "Garantii periood",
   :land-acquisition/pos-number "POS#",
+  :company/country "Riik",
   :meeting.agenda/responsible "Vastutav isik",
   :document/sub-category "Dokumendi alamtüüp",
   :location/road-address "Tee aadress",
@@ -836,6 +877,7 @@
   :land-owner-opinion/activity "Tegevus",
   :file/timestamp "Üleslaadimise kuupäev",
   :cooperation.3rd-party/email "E-post",
+  :company/phone-numbers "Ettevõtte telefoni number",
   :user/email "E-post",
   :land-acquisition/area-to-obtain "Omandatav ala",
   :file/sequence-number "#",
@@ -854,6 +896,7 @@
   :meeting/links "Lingid",
   :activity/name "Tegevuse nimi",
   :location/start-km "Algus km",
+  :company/emails "Ettevõtte e-posti aadress",
   :estate-compensation/amount "Summa",
   :document/category "Dokumendi tüüp",
   :boq-version/type "Värskenda versiooni olekut",
@@ -885,18 +928,18 @@
   :upload-info "Üles laadinud {author} {date} ",
   :upload-success "Fail edukalt üleslaetud",
   :export-files-zip
-  {:email-body "Lae alla siit: \n{link} \nLink kehtib 24 tundi.",
-   :activity-button
+  {:activity-button
    "Saadan viite tegevusega seotud failidele e-postiga",
-   :task-button "Saadan viite ülesandega seotud failidele e-postiga",
    :activity-email-subject
    "Tegevusega seotud dokumentide eksport on lõppenud",
    :activity-success
    "Toimub tegevusega seotud dokumentide eksport. Dokumentide link saadetakse sulle peagi e-postiga",
-   :task-success
-   "Toimub ülesandega seotud dokumentide eksport. Dokumentide link saadetakse sulle peagi e-postiga",
+   :email-body "Lae alla siit: \n{link} \nLink kehtib 24 tundi.",
+   :task-button "Saadan viite ülesandega seotud failidele e-postiga",
    :task-email-subject
-   "Ülesandega seotud dokumentide eksport on lõppenud"},
+   "Ülesandega seotud dokumentide eksport on lõppenud",
+   :task-success
+   "Toimub ülesandega seotud dokumentide eksport. Dokumentide link saadetakse sulle peagi e-postiga"},
   :replace-dialog-title "Laen üles uue versiooni",
   :edit-info "Viimati muudetud {author} {date} ",
   :other-versions "Muud versioonid",
@@ -905,10 +948,10 @@
   :full-name "TEET failinimi",
   :switch-to-latest-version "Lülitan tagasi uusimale versioonile",
   :sort-by
-  {:file/type "Sorteerin failitüübi järgi",
-   :meta/created-at "Sorteerin kuupäeva järgi",
-   :file/name "Sorteerin nime järgi",
-   :file/status "Sorteerin staatuse järgi"},
+  {:file/name "Sorteerin nime järgi",
+   :file/status "Sorteerin staatuse järgi",
+   :file/type "Sorteerin failitüübi järgi",
+   :meta/created-at "Sorteerin kuupäeva järgi"},
   :replace-dialog-info-text
   "Ära muretse, eelmine versioon jääb alles ning sa leiad selle faili detailvaatest.",
   :version "Versioon {num}",
@@ -975,9 +1018,9 @@
   :cadastral-filter-label "Katastriüksuse number",
   :unit-name-id "Üksuse nimi ja tunnus",
   :quality
-  {:bad "Halb",
+  {:any "Kõik",
+   :bad "Halb",
    :good "Hea (L-Est)",
-   :any "Kõik",
    :questionable "Küsitav"},
   :filter-label "Filtreerin üksused",
   :total-excluding-process "Kokku ilma protseduuri tasudeta:",
@@ -1001,12 +1044,12 @@
   :comments "Märkused",
   :mortgages "Hüpoteeki",
   :modal-title
-  {:mortgages "Hüpoteegid",
-   :burdens "Koormatised",
-   :costs "Kulud",
-   :owners-opinions "Maade omanike arvamused",
+  {:burdens "Koormatised",
    :comments "Märkused",
-   :files "Üksusega seotud failid"},
+   :costs "Kulud",
+   :files "Üksusega seotud failid",
+   :mortgages "Hüpoteegid",
+   :owners-opinions "Maade omanike arvamused"},
   :costs "Kulud",
   :mortgage "Hüpoteek",
   :owner-opinions "Arvamused",
@@ -1024,10 +1067,9 @@
   :choose-activity "Valin tegevuse",
   :update {:success-message "Arvamuse muutmine õnnestus"},
   :delete
-  {:success-message "Arvamus kustutatud",
-   :cancel-text "Ei, pöördun tagasi",
-   :confirmation-text
-   "Kogu info kustutatakse ja seda ei saa taastada"},
+  {:cancel-text "Ei, pöördun tagasi",
+   :confirmation-text "Kogu info kustutatakse ja seda ei saa taastada",
+   :success-message "Arvamus kustutatud"},
   :export
   {:units-with-opinions "1.1 Piirnevate kinnisasjade omanikud",
    :estate-num-name "Kinnisasja number; Kinnisasja nimi",
@@ -1044,26 +1086,28 @@
   :choose-type "Valin liigi",
   :edit-opinion "MUUDAN ARVAMUST"},
  :link
- {:search
+ {:land-unit-not-in-project "Projektis pole valitud",
+  :no-units-in-estate-selected "Projektis pole valitud üksusi",
+  :search
   {:no-results "Ei leitud ühtki vastet",
    :placeholder "Lisan viite..."},
+  :target-deleted "Kustutatud {user} poolt {at}",
   :type-label
-  {:file "Fail",
+  {:appendix "Lisa",
    :cadastral-unit "Katastriüksus",
    :estate "Kinnistu",
-   :appendix "Lisa",
-   :task "Ülesanne"},
-  :target-deleted "Kustutatud {user} poolt {at}",
-  :land-unit-not-in-project "Projektis pole valitud",
-  :no-units-in-estate-selected "Projektis pole valitud üksusi"},
+   :file "Fail",
+   :task "Ülesanne"}},
  :login
- {:username "Kasutaja",
-  :password "Salasõna",
+ {:greetings-text
+  "Tee elukaare teabe ning andmete haldamise ja vahetamise keskkond TEET",
   :login "Sisenen",
-  :greetings-text
-  "Tee elukaare teabe ning andmete haldamise ja vahetamise keskkond TEET"},
+  :password "Salasõna",
+  :username "Kasutaja"},
  :map
  {:aerial-view "Aerofoto",
+  :clear-selections "Tühjendan valikud",
+  :display "Kaardi tüüp",
   :layers
   {:no-filters "Filtrid või lisakihid puuduvad",
    :projects "Projektid",
@@ -1076,9 +1120,7 @@
    :cadastral-units "Katastriüksused",
    :no-layers "Kihid puuduvad",
    :land-surveys "Maa uuring"},
-  :display "Kaardi tüüp",
   :map-layers "Kaardikihid",
-  :clear-selections "Tühjendan valikud",
   :select-all "Valin kõik"},
  :meeting
  {:notifications-help
@@ -1185,12 +1227,12 @@
  :page-title {:project-list "{name} projekt"},
  :people-tab
  {:active "AKTIIVNE",
-  :managers "Juhid",
   :consultants "Konsultandid",
-  :invite-user "Lisan uue kasutaja",
-  :other-users "Muud kasutajad",
   :hide-history "Peidan ajaloo",
+  :invite-user "Lisan uue kasutaja",
+  :managers "Juhid",
   :no-other-users "Teisi kasutajaid pole",
+  :other-users "Muud kasutajad",
   :show-history "Vaatan ajalugu"},
  :project
  {:add-users "Lisan kasutajaid",
@@ -1235,14 +1277,14 @@
   :add-task "Lisan ülesande",
   :draw-selection
   {:deselect "Eemaldan nimekirjast",
-   :select "Lisan nimekirja",
-   :link "Valin alad kaardilt"},
+   :link "Valin alad kaardilt",
+   :select "Lisan nimekirja"},
   :information
-  {:estimated-duration "Eeldatav kestus",
-   :procurement-number "Hanke number",
+  {:carriageway "SO",
+   :estimated-duration "Eeldatav kestus",
    :km-range "Km ulatus",
+   :procurement-number "Hanke number",
    :repair-method "Meede",
-   :carriageway "SO",
    :road-number "Tee number"},
   :add-tasks "Lisan ülesandeid",
   :activities "Projekti tegevused",
@@ -1254,20 +1296,20 @@
   :activities-tab "Tegevused"},
  :project-groups {:title "Projektirühmad"},
  :projects
- {:map-view "Kaart",
-  :filters
+ {:filters
   {:all "Kõik projektid",
-   :unassigned-only "Määramata projektid",
-   :my-projects "Minu projektid"},
-  :title "Projektid",
+   :my-projects "Minu projektid",
+   :unassigned-only "Määramata projektid"},
   :list-view "Projektide loetelu",
-  :no-activities "Tegevused puuduvad"},
+  :map-view "Kaart",
+  :no-activities "Tegevused puuduvad",
+  :title "Projektid"},
  :roles
  {:authenticated-guest "Autenditud külaline",
-  :guest "Külaline",
-  :manager "Projektijuht",
-  :internal-consultant "Sisemine konsultant",
   :external-consultant "Väline konsultant",
+  :guest "Külaline",
+  :internal-consultant "Sisemine konsultant",
+  :manager "Projektijuht",
   :owner "Vastutav isik"},
  :search {:clear-filters "Eemaldan filtrid", :quick-search "Otsin"},
  :search-area
@@ -1290,11 +1332,11 @@
   "Sisestan väärtuse seotud piirkondade kuvamiseks",
   :component-title "Seotud objektide otsinguala"},
  :tab-names
- {:upcoming "Eesolevad",
-  :notes "Märkused",
+ {:decisions "Otsused",
+  :details "Üksikasjad",
   :history "Möödunud",
-  :decisions "Otsused",
-  :details "Üksikasjad"},
+  :notes "Märkused",
+  :upcoming "Eesolevad"},
  :task
  {:task-overview "Ülesande ülevaade",
   :edit-part-modal-title "Muudan ülesande osa",
@@ -1350,15 +1392,15 @@
  :unit-info {:owners-opinions "Maade omanike arvamused"},
  :unit-modal-page {:add-new-owner-opinion "Lisan uue arvamuse"},
  :user
- {:unregistered "Kasutaja",
-  :autocomplete
-  {:no-options "Kasutajat ei leitud",
-   :loading "Otsin kasutajaid...",
+ {:autocomplete
+  {:loading "Otsin kasutajaid...",
+   :no-options "Kasutajat ei leitud",
    :placeholder "Sisestan nime..."},
-  :role "Roll"},
+  :role "Roll",
+  :unregistered "Kasutaja"},
  :validation {:invalid-email "Vale emaili aadress"},
  :warning
- {:version-mismatch
-  "Rakenduse uus versioon on laetud. Palun värskenda lehte.",
-  :deploying
-  "Rakenduse uut versiooni laetakse. Palun oota mõned minutid ning seejärel värskenda lehte."}}
+ {:deploying
+  "Rakenduse uut versiooni laetakse. Palun oota mõned minutid ning seejärel värskenda lehte.",
+  :version-mismatch
+  "Rakenduse uus versioon on laetud. Palun värskenda lehte."}}

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -92,6 +92,7 @@
   :manager {:link "Varad", :result-count "{count} nähtust"},
   :components {:label "Komponendid"},
   :back-to-cost-item "< Tagasi {name}",
+  :materials {:label "Materjalid"},
   :location
   {:hide-map "Peida kaart",
    :no-road-found-for-points "Punktide jaoks ei leitud teed",
@@ -221,6 +222,7 @@
  :contract
  {:no-targets-for-contract
   "Lepingu integreerimine ei õnnestunud ja sellel lepingul pole kehtivaid eesmärke.\nVeateate saamiseks pöörduge administratsiooni poole",
+  :partner-information-text nil,
   :thk.contract.status/deadline-approaching "Tähtaeg läheneb",
   :company-search-placeholder
   "Sisesta ettevõtte nimi või äriregistri kood",

--- a/app/common/src/cljc/teet/asset/asset_model.cljc
+++ b/app/common/src/cljc/teet/asset/asset_model.cljc
@@ -57,6 +57,7 @@
 
 (def ^:private asset-pattern #"^...-\w{3}-\d{6}$")
 (def ^:private component-pattern #"^...-\w{3}-\d{6}-\d{5}$")
+(def ^:private material-pattern #"^...-\w{3}-\d{6}-\d{5}-\d{3}$")
 
 (defn asset-oid?
   "Check if given OID refers to asset."
@@ -69,6 +70,12 @@
   [oid]
   (and (string? oid)
        (boolean (re-matches component-pattern oid))))
+
+(defn material-oid?
+  "Check if given OID refers to a material."
+  [oid]
+  (and (string? oid)
+       (boolean (re-matches material-pattern oid))))
 
 (defn asset-oid->fclass-oid-prefix
   "Extract the asset fclass OID prefix from an asset OID instance."
@@ -88,6 +95,13 @@
   {:post [(component-oid? %)]}
   (format "%s-%05d" asset-oid sequence-number))
 
+(defn material-oid
+  "Format component OID for asset OID and seq number."
+  [component-oid sequence-number]
+  {:pre [(component-oid? component-oid)]
+   :post [(material-oid? %)]}
+  (format "%s-%03d" component-oid sequence-number))
+
 (defn component-asset-oid
   "Given component OID, return the OID of the parent asset."
   [component-oid]
@@ -98,7 +112,8 @@
       (->> (str/join "-"))))
 
 (defn find-component-path
-  "Return vector containing all parents of component from asset to the component.
+  "Return vector containing all parents of component or material from asset to
+  the component or material.
   For example:
   [a c1 c2 c3]
   where a is the asset, that has component c1
@@ -106,22 +121,9 @@
   and c2 has child component c3 (the component we want)"
   [asset component-oid]
   (cu/find-path #(concat (:asset/components %)
-                         (:component/components %))
-                #(= component-oid (:asset/oid %))
-                asset))
-
-(defn find-material-path
-  "Return vector containing all parents of component from asset to the component.
-  For example:
-  [a c1 c2 c3]
-  where a is the asset, that has component c1
-  c1 has child component c2
-  and c2 has child component c3 (the component we want)"
-  [asset material-id]
-  (cu/find-path #(concat (:asset/components %)
                          (:component/components %)
                          (:component/materials %))
-                #(= material-id (:db/id %))
+                #(= component-oid (:asset/oid %))
                 asset))
 
 (def cost-totals-table-columns

--- a/app/common/src/cljc/teet/asset/asset_model.cljc
+++ b/app/common/src/cljc/teet/asset/asset_model.cljc
@@ -110,6 +110,20 @@
                 #(= component-oid (:asset/oid %))
                 asset))
 
+(defn find-material-path
+  "Return vector containing all parents of component from asset to the component.
+  For example:
+  [a c1 c2 c3]
+  where a is the asset, that has component c1
+  c1 has child component c2
+  and c2 has child component c3 (the component we want)"
+  [asset material-id]
+  (cu/find-path #(concat (:asset/components %)
+                         (:component/components %)
+                         (:component/materials %))
+                #(= material-id (:db/id %))
+                asset))
+
 (def cost-totals-table-columns
   [:type :properties :common/status :quantity :cost-per-quantity-unit :total-cost])
 

--- a/app/common/src/cljc/teet/asset/asset_model.cljc
+++ b/app/common/src/cljc/teet/asset/asset_model.cljc
@@ -111,6 +111,14 @@
       butlast
       (->> (str/join "-"))))
 
+(defn material-asset-oid
+  "Given material OID, return the OID of the parent asset."
+  [material-oid]
+  {:pre [(material-oid? material-oid)]}
+  (->> (str/split material-oid #"-")
+       (drop-last 2)
+       (str/join "-")))
+
 (defn find-component-path
   "Return vector containing all parents of component or material from asset to
   the component or material.

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -323,7 +323,6 @@
                       (update parent :component/materials
                               #(conj (or % [])
                                      {:db/id new-id
-                                      ;; For the time being, this is used for compatibility with existing code
                                       :asset/oid new-id
                                       :material/type type}))))
        {:tuck.effect/type :navigate
@@ -354,7 +353,7 @@
       (let [form-data (form-state app)
             {parent-id :asset/oid}
             (-> (common-controller/page-state app :cost-item)
-                (asset-model/find-material-path (:db/id form-data))
+                (asset-model/find-component-path (:asset/oid form-data))
                 butlast last)]
         (cljs.pprint/pprint form-data)
         (t/fx app
@@ -363,7 +362,6 @@
                :payload {:project-id (get-in app [:params :project])
                          :parent-id parent-id
                          :material (dissoc form-data
-                                           :asset/oid
                                            :material/materials
                                            :location/geojson)}
                :result-event ->SaveMaterialResponse}))))

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -10,8 +10,7 @@
             [teet.routes :as routes]
             cljs.reader
             [teet.asset.asset-type-library :as asset-type-library]
-            [reagent.core :as r]
-            [teet.ui.format :as format]))
+            [reagent.core :as r]))
 
 (defrecord AddComponentCancel [id])
 
@@ -75,6 +74,9 @@
 (defrecord DeleteComponent [id])
 (defrecord SaveComponent [component-id])
 (defrecord SaveComponentResponse [response])
+(defrecord DeleteMaterial [id])
+(defrecord SaveMaterial [material-id])
+(defrecord SaveMaterialResponse [response])
 
 (defrecord UpdateForm [form-data])
 

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -125,8 +125,7 @@
      ;; component query parameter specifies new component to add
      (get-in app [:query :material])
      ;; or existing material
-     (when (and (not (asset-model/component-oid? id))
-                (not (asset-model/asset-oid? id)))
+     (when (asset-model/material-oid? id)
        id))))
 
 (defn- children-by-key [asset-or-component k]

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -77,6 +77,8 @@
 (defrecord DeleteMaterial [id])
 (defrecord SaveMaterial [material-id])
 (defrecord SaveMaterialResponse [response])
+(defrecord AddMaterial [type])
+(defrecord UpdateMaterialForm [form-data])
 
 (defrecord UpdateForm [form-data])
 
@@ -116,15 +118,39 @@
      (and (asset-model/component-oid? id)
           id))))
 
+(defn- form-material-id [app]
+  (let [id (get-in app [:params :id])]
+    (or
+     ;; component query parameter specifies new component to add
+     (get-in app [:query :material])
+     ;; or existing material
+     (when (and (not (asset-model/component-oid? id))
+                (not (asset-model/asset-oid? id)))
+       id))))
+
+(defn- children-by-key [asset-or-component k]
+  (when-let [children (not-empty (k asset-or-component))]
+    [k children]))
+
+(defn- children
+  "Find children of the asset or component, returning [<chilren-key> <children>],
+   eg. [:component/materials <materials>]"
+  [asset-or-component]
+  (->> [:asset/components :component/components :component/materials]
+       (map (partial children-by-key asset-or-component))
+       (some identity)))
+
 (defn- form-state
   "Return the current form state."
   [app]
-  (if-let [component-id (form-component-id app)]
+  (if-let [target-id (or (form-material-id app)
+                         (form-component-id app))]
     ;; Get some nested component by id
     (let [by-id (fn by-id [{oid :asset/oid :as c}]
-                  (if (= component-id oid)
+                  (if (= target-id oid)
                     c
-                    (some by-id (:component/components c))))]
+                    (let [[_ cs] (children c)]
+                      (some by-id cs))))]
       (some by-id
             (common-controller/page-state app :cost-item :asset/components)))
 
@@ -136,8 +162,8 @@
           (let [c (if (= component-id oid)
                     (apply update-fn c args)
                     c)]
-            (if-let [sub-components (:component/components c)]
-              (assoc c :component/components
+            (if-let [[subcomponent-key sub-components] (children c)]
+              (assoc c subcomponent-key
                      (update-component sub-components component-id update-fn args))
               c))) components))
 
@@ -154,6 +180,15 @@
     ;; Update asset itself
     (apply common-controller/update-page-state
            app [:cost-item] update-fn args)))
+
+(defn- update-material-form
+  "Update material form state."
+  [app update-fn & args]
+  ;; Update some nested component by id
+  (common-controller/update-page-state
+   app [:cost-item :asset/components]
+   update-component (form-material-id app) update-fn args))
+
 
 (def locked?
   "Check from app state if BOQ version is locked."
@@ -278,6 +313,81 @@
                                         {:id oid})
                          :query nil})
                       common-controller/refresh-fx]))))
+
+  AddMaterial
+  (process-event [{:keys [type component-oid]} {:keys [page params query] :as app}]
+    (let [new-id (next-id! "m")]
+      (t/fx
+       (update-form app
+                    (fn [parent]
+                      (update parent :component/materials
+                              #(conj (or % [])
+                                     {:db/id new-id
+                                      ;; For the time being, this is used for compatibility with existing code
+                                      :asset/oid new-id
+                                      :material/type type}))))
+       {:tuck.effect/type :navigate
+        :params params
+        :page page
+        :query (merge query {:material new-id})})))
+
+  DeleteMaterial
+  (process-event [{:keys [fetched-cost-item-atom id]} app]
+    (if (locked? app)
+      (do
+        (log/debug "Not deleting material, BOQ version is locked.")
+        app)
+      (let [project-id (get-in app [:params :project])]
+        (t/fx app
+              {:tuck.effect/type :command!
+               :command :asset/delete-material ;; TODO does not yet exist
+               :payload {:db/id id
+                         :project-id project-id}
+               :result-event common-controller/->Refresh}))))
+
+  SaveMaterial
+  (process-event [_ app]
+    (if (locked? app)
+      (do
+        (log/debug "Not saving, BOQ version is locked.")
+        app)
+      (let [form-data (form-state app)
+            {parent-id :asset/oid}
+            (-> (common-controller/page-state app :cost-item)
+                (asset-model/find-material-path (:db/id form-data))
+                butlast last)]
+        (cljs.pprint/pprint form-data)
+        (t/fx app
+              {:tuck.effect/type :command!
+               :command :asset/save-material
+               :payload {:project-id (get-in app [:params :project])
+                         :parent-id parent-id
+                         :material (dissoc form-data
+                                           :asset/oid
+                                           :material/materials
+                                           :location/geojson)}
+               :result-event ->SaveMaterialResponse}))))
+
+  SaveMaterialResponse
+  (process-event [{:keys [response]} {params :params :as app}]
+    (let [oid (:asset/oid response)]
+      (apply t/fx app
+             (remove nil?
+                     [(when (not= oid (params :id))
+                        {:tuck.effect/type :navigate
+                         :page :cost-item
+                         :params (merge (:params app)
+                                        {:id oid})
+                         :query nil})
+                      common-controller/refresh-fx]))))
+
+  UpdateMaterialForm
+  (process-event [{:keys [form-data]} app]
+    (if (locked? app)
+      (do
+        (log/debug "Not editing form, BOQ version is locked.")
+        app)
+      (update-material-form app #(merge % form-data))))
 
   UpdateForm
   (process-event [{:keys [form-data]} app]

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -79,6 +79,7 @@
 (defrecord SaveMaterialResponse [response])
 (defrecord AddMaterial [type])
 (defrecord UpdateMaterialForm [form-data])
+(defrecord ResetMaterialForm [form-data])
 
 (defrecord UpdateForm [form-data])
 
@@ -339,7 +340,7 @@
       (let [project-id (get-in app [:params :project])]
         (t/fx app
               {:tuck.effect/type :command!
-               :command :asset/delete-material ;; TODO does not yet exist
+               :command :asset/delete-material
                :payload {:db/id id
                          :project-id project-id}
                :result-event common-controller/->Refresh}))))
@@ -387,8 +388,17 @@
         app)
       (update-material-form app #(merge % form-data))))
 
+  ResetMaterialForm
+  (process-event [{:keys [form-data]} app]
+    (if (locked? app)
+      (do
+        (log/debug "Not editing form, BOQ version is locked.")
+        app)
+      (update-material-form app (constantly form-data))))
+
   UpdateForm
   (process-event [{:keys [form-data]} app]
+    (println "UpdateForm")
     (if (locked? app)
       (do
         (log/debug "Not editing form, BOQ version is locked.")

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -356,7 +356,6 @@
             (-> (common-controller/page-state app :cost-item)
                 (asset-model/find-component-path (:asset/oid form-data))
                 butlast last)]
-        (cljs.pprint/pprint form-data)
         (t/fx app
               {:tuck.effect/type :command!
                :command :asset/save-material
@@ -398,7 +397,6 @@
 
   UpdateForm
   (process-event [{:keys [form-data]} app]
-    (println "UpdateForm")
     (if (locked? app)
       (do
         (log/debug "Not editing form, BOQ version is locked.")

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -676,7 +676,6 @@
                               #(cost-items-controller/->ResetMaterialForm initial-material-data))]
     (let [material-path (asset-model/find-component-path cost-item-data material-oid)
           material-data (last material-path)]
-      (println material-oid material-data)
       [:<>
        (when (asset-model/material-oid? material-oid)
          [typography/Heading2 material-oid])

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -546,7 +546,6 @@
                        {:e! e!
                         :attributes (some-> feature-class :attribute/_parent)
                         :cost-item-data form-data
-                        ;; TODO: cost-item-data here as well
                         :common :ctype/feature
                         :inherits-location? false
                         :relevant-roads relevant-roads}]])
@@ -643,7 +642,6 @@
              [add-component-menu
               (tr [:asset :add-material])
               allowed-materials
-              ;; TODO: AddMaterial
               (e! cost-items-controller/->AddMaterial)])])
 
         [:div {:class (<class common-styles/flex-row-space-between)

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -632,7 +632,7 @@
           [materials-list component-data {:e! e! :atl atl}])
 
         (when (not new?)
-          [:<>
+          [:div
            ;; Should have only either, never both
            (when-let [allowed-components (not-empty (asset-type-library/allowed-component-types atl ctype))]
              [add-component-menu

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -534,10 +534,6 @@
           [add-component-menu
            (into []
                  (asset-type-library/allowed-component-types atl fclass))
-           (e! cost-items-controller/->AddComponent)]
-          [add-component-menu
-           (into []
-                 (asset-type-library/allowed-material-types atl fclass))
            (e! cost-items-controller/->AddComponent)]])])))
 
 (defn- component-form-navigation [atl [asset :as component-path]]
@@ -610,10 +606,17 @@
          [form/footer2]]]
 
        (when (not new?)
-         (let [allowed-components (asset-type-library/allowed-component-types atl ctype)]
-           (when (seq allowed-components)
-             [add-component-menu allowed-components
-              (e! cost-items-controller/->AddComponent)])))])))
+         [:<>
+          ;; Should have only either, never both
+          (when-let [allowed-components (not-empty (asset-type-library/allowed-component-types atl ctype))]
+            [add-component-menu
+             allowed-components
+             (e! cost-items-controller/->AddComponent)])
+          (when-let [allowed-materials (asset-type-library/allowed-material-types atl ctype)]
+            [add-component-menu
+             allowed-materials
+             ;; TODO: AddMaterial
+             (e! cost-items-controller/->AddComponent)])])])))
 
 (defn component-form
   [e! atl component-oid cost-item-data]

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -532,7 +532,12 @@
                             :allowed-components (:ctype/_parent feature-class)}]
 
           [add-component-menu
-           (asset-type-library/allowed-component-types atl fclass)
+           (into []
+                 (asset-type-library/allowed-component-types atl fclass))
+           (e! cost-items-controller/->AddComponent)]
+          [add-component-menu
+           (into []
+                 (asset-type-library/allowed-material-types atl fclass))
            (e! cost-items-controller/->AddComponent)]])])))
 
 (defn- component-form-navigation [atl [asset :as component-path]]

--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -630,7 +630,7 @@
 
 (defn- material-form* [e! atl material-oid cost-item-data]
   (r/with-let [initial-material-data
-               (last (asset-model/find-material-path cost-item-data
+               (last (asset-model/find-component-path cost-item-data
                                                       material-oid))
                new? (string? (:db/id initial-material-data))
                material-type (asset-type-library/item-by-ident
@@ -639,7 +639,7 @@
                cancel-event (if new?
                               #(common-controller/->SetQueryParam :material nil)
                               #(cost-items-controller/->UpdateForm initial-material-data))]
-    (let [material-path (asset-model/find-material-path cost-item-data material-oid)
+    (let [material-path (asset-model/find-component-path cost-item-data material-oid)
           material-data (last material-path)]
       (println material-oid material-data)
       [:<>
@@ -676,7 +676,7 @@
 
 (defn material-form
   [e! atl material-id cost-item-data]
-  (if (nil? (asset-model/find-material-path cost-item-data material-id))
+  (if (nil? (asset-model/find-component-path cost-item-data material-id))
     [CircularProgress]
     [material-form* e! atl material-id cost-item-data]))
 


### PR DESCRIPTION
This PR implements the basic CRUD operations for materials. Materials can only for components that are leafs in the asset type hierarchy.

What's _not_ implemented:
- Cost group functionality for materials
- Adding materials with no attributes (I assume this there are none as they get specified)