### PR TITLE
TEET-1676 Pass options recursively to subcomponent

### DIFF
--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -461,6 +461,8 @@
          [component-rows {:e! e!
                           :locked? locked?
                           :components (:component/components c)
+                          :children-label-fn children-label-fn
+                          :delete-fn delete-fn
                           :level (inc (or level 0))}]]))]))
 
 (defn- children-tree*


### PR DESCRIPTION
This PR fixes a bug where certain component options weren't passed recursively to subcomponent.