### PR TITLE
TEET-1688 Remove separator space from fromatted numbers when parsing

### DIFF
--- a/app/common/src/cljc/teet/util/coerce.cljc
+++ b/app/common/src/cljc/teet/util/coerce.cljc
@@ -9,6 +9,8 @@
   [x]
   (when (string? x)
     (-> x str/trim
+        ;; Removes the formatted number separator space whereas \s does not
+        (str/replace #"\h" "")
         (str/replace #"\s" "")
         (str/replace "," ".")
         (str/replace "−" "-"))))


### PR DESCRIPTION
This PR adds back the \h separator that seemed useless.