### PR TITLE
Increase Cypress login timeout to prevent flaky tests

### DIFF
--- a/ci/browser-tests/cypress/support/commands.js
+++ b/ci/browser-tests/cypress/support/commands.js
@@ -19,7 +19,7 @@ Cypress.Commands.add("dummyLogin", (name) => {
     })
 
     // Redirects to map page
-    cy.location("hash").should("eq", "#/projects/map")
+    cy.location("hash", {timeout: 30000}).should("eq", "#/projects/map")
 
 })
 


### PR DESCRIPTION
This PR will increase the Cypress login timeout to 30 seconds.