### PR TITLE
TEET-1712 Material grouping

### DIFF
--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -265,9 +265,11 @@
   (let [ctype (-> material :component/_materials :component/ctype)
         fclass (asset-type-library/fclass-for-ctype atl ctype)
         fgroup (asset-type-library/fgroup-for-fclass atl fclass)]
-        (assoc material
-           :fclass (select-keys fclass [:db/id :db/ident :asset-schema/label])
-           :fgroup (select-keys fgroup [:db/id :db/ident :asset-schema/label]))))
+    (update material
+            :component/_materials
+            assoc
+            :fclass (select-keys fclass [:db/id :db/ident :asset-schema/label])
+            :fgroup (select-keys fgroup [:db/id :db/ident :asset-schema/label]))))
 
 (defn- select-material-grouping-attributes [entity atl]
   (-> entity
@@ -281,7 +283,8 @@
        (map #(select-material-grouping-attributes % atl))
        (group-by #(dissoc % :db/id :component/_materials))
        (map (fn [[group materials]]
-              (assoc group :component/_materials  (map :component/_materials materials))))))
+              (assoc group :component/_materials  (map :component/_materials materials))))
+       spy))
 
 (defn- cost-group-attrs-q
   "Return all items in project with type, status and cost grouping attributes.

--- a/app/backend/src/clj/teet/asset/asset_db.clj
+++ b/app/backend/src/clj/teet/asset/asset_db.clj
@@ -283,8 +283,7 @@
        (map #(select-material-grouping-attributes % atl))
        (group-by #(dissoc % :db/id :component/_materials))
        (map (fn [[group materials]]
-              (assoc group :component/_materials  (map :component/_materials materials))))
-       spy))
+              (assoc group :component/_materials  (map :component/_materials materials))))))
 
 (defn- cost-group-attrs-q
   "Return all items in project with type, status and cost grouping attributes.

--- a/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_controller.cljs
@@ -735,22 +735,30 @@
             (filter filter-pred))
            cost-group-totals)]))
 
-(defn material-used-in-fgroup-fclass-or-ctype? [fgroup-or-fclass material]
+(defn material-used-in-fgroup-fclass-or-ctype?
+  "Is the material used for the given feature group, feature class or
+  component type? It is used if there is a component in the project that
+  - is of the given component type or
+  - the component belongs to the given feature class or feature group"
+  [fgroup-fclass-or-ctype material]
   (->> material
        :component/_materials
        (map (comp (partial map :db/ident)
                   (juxt :fgroup :fclass :component/ctype)))
-       (some (partial some (partial = fgroup-or-fclass)))))
+       (some (partial some (partial = fgroup-fclass-or-ctype)))))
 
-(defn remove-nonmatching-components [fgroup-or-fclass material]
-  (if (nil? fgroup-or-fclass)
+(defn remove-nonmatching-components
+  "Removes components that don't belong to the given feature group,
+  feature class or component type"
+  [fgroup-fclass-or-ctype material]
+  (if (nil? fgroup-fclass-or-ctype)
     material
     (update material
            :component/_materials
            #(filter (fn [component]
                       (->> ((juxt :fgroup :fclass :component/ctype) component)
                            (map :db/ident)
-                           (some (partial = fgroup-or-fclass))))
+                           (some (partial = fgroup-fclass-or-ctype))))
                     %))))
 
 (defn filtered-materials-and-products

--- a/app/frontend/src/cljs/teet/asset/materials_and_products_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/materials_and_products_view.cljs
@@ -53,39 +53,21 @@
     :parameter (format-properties atl value)
     (str value)))
 
-(defn- table-section-header [e! query listing-opts closed-set {ident :db/ident :as header-type} subtotal]
-  [table/listing-table-body-component listing-opts
-   [container/collapsible-container-heading
-    {:container-class [(<class common-styles/flex-row)
-                       (when (= "fclass" (namespace ident))
-                         (<class common-styles/indent-rem 1))]
-     :open? (not (closed-set ident))
-     :on-toggle (e! cost-items-controller/->ToggleOpenTotals ident)}
-    [:<>
-     [url/Link {:page :materials-and-products
-                :query (merge query {:filter (str ident)})}
-      (asset-ui/label header-type)]
-     (when subtotal
-       [:div {:style {:float :right :font-weight 700
-                      :font-size "80%"}} subtotal])]]])
-
-
 (defn- materials-and-products-page*
   [e! {query :query atl :asset-type-library :as app}
    {materials-and-products :materials-and-products
     version :version
-    closed-sections :closed-sections
-    :or {closed-sections #{}}
     :as state}]
   (r/with-let [listing-state (table/listing-table-state)]
     (let [locked? (asset-model/locked? version)
+          format-column (r/partial format-material-table-column
+                                   {:e! e! :atl atl :locked? locked?})
           listing-opts {:columns asset-model/materials-and-products-table-columns
                         :get-column (r/partial get-column atl)
                         :column-label-fn #(if (= % :common/status)
                                             (asset-ui/label (asset-type-library/item-by-ident atl %))
                                             (tr [:asset :totals-table %]))
-                        :format-column (r/partial format-material-table-column
-                                                  {:e! e! :atl atl :locked? locked?})}
+                        :format-column format-column}
 
           [filter-fg-or-fc filtered-materials-and-products]
           (cost-items-controller/filtered-materials-and-products app atl
@@ -113,7 +95,8 @@
          [table/listing-header (assoc listing-opts :state listing-state)]
          [table/listing-body (assoc listing-opts
                                     :key (comp str #(get-column atl % :parameter))
-                                    :rows filtered-materials-and-products)]]]])))
+                                    :rows (sort-by #(format-column :material % nil)
+                                                   filtered-materials-and-products))]]]])))
 
 (defn materials-and-products-page [e! app state]
   [asset-ui/wrap-atl-loader materials-and-products-page* e! app state])

--- a/app/frontend/src/cljs/teet/asset/materials_and_products_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/materials_and_products_view.cljs
@@ -111,30 +111,9 @@
          [typography/Heading1 "Materials"]]
         [table/listing-table-container
          [table/listing-header (assoc listing-opts :state listing-state)]
-         (doall
-          (for [[fg fgroup-rows] (->> filtered-materials-and-products
-                                      (group-by (comp first :ui/group))
-                                      ;; sort by translated fgroup label
-                                      (sort-by (comp asset-ui/label first)))
-                :let [ident (:db/ident fg)
-                      open? (not (closed-sections ident))]]
-            ^{:key (str ident)}
-            [:<>
-             [table-section-header e! query listing-opts closed-sections fg nil]
-             (when open?
-               [:<>
-                (doall
-                 (for [[fc fclass-rows] (group-by (comp second :ui/group)
-                                                  fgroup-rows)
-                       :let [ident (:db/ident fc)
-                             open? (not (closed-sections ident))]]
-                   ^{:key (str ident)}
-                   [:<>
-                    [table-section-header e! query listing-opts closed-sections fc nil]
-                    (when open?
-                      [table/listing-body (assoc listing-opts
-                                                 :key (comp str #(get-column atl % :parameter))
-                                                 :rows fclass-rows)])]))])]))]]])))
+         [table/listing-body (assoc listing-opts
+                                    :key (comp str #(get-column atl % :parameter))
+                                    :rows filtered-materials-and-products)]]]])))
 
 (defn materials-and-products-page [e! app state]
   [asset-ui/wrap-atl-loader materials-and-products-page* e! app state])


### PR DESCRIPTION
This PR
- removes subheadings from materials and products page
- doesn't group materials by feature groups and classes any more
- retains filtering by feature groups and classes