### PR TITLE
TEET-1694 minor select fixes

### DIFF
--- a/app/frontend/src/cljs/teet/ui/select.cljs
+++ b/app/frontend/src/cljs/teet/ui/select.cljs
@@ -408,20 +408,28 @@
                on-key-down (partial arrow-navigation state on-change)]
     (let [{:keys [loading? results open? input highlight]} @state
           current-input-ref (or (:input-ref opts) @input-ref)
-          load! #(let [result-fn-or-query-map (query %)]
-                   (if (fn? result-fn-or-query-map)
-                     (let [results (result-fn-or-query-map)]
-                       (swap! state merge {:loading? false
-                                           :open? true
-                                           :results results
-                                           :highlight (first results)}))
-                     (e! (->CompleteSearch result-fn-or-query-map
-                                           (fn [results]
-                                             (swap! state assoc
-                                                    :loading? false
-                                                    :open? true
-                                                    :results results
-                                                    :highlight (first results)))))))]
+          load! (fn [text]
+                  (let [result-fn-or-query-map (query text)]
+                    (if (fn? result-fn-or-query-map)
+                      (let [results (result-fn-or-query-map)]
+                        (swap! state merge {:loading? false
+                                            :open? true
+                                            :results results
+                                            :highlight (first results)}))
+                      (e! (->CompleteSearch
+                           result-fn-or-query-map
+                           (fn [results]
+                             (swap! state
+                                    (fn [state]
+                                      (if-not (= text (:input state))
+                                        (do
+                                          (log/debug "Stale result for:" text)
+                                          state)
+                                        (assoc state
+                                               :loading? false
+                                               :open? true
+                                               :results results
+                                               :highlight (first results)))))))))))]
       [:<>
        [input-element
         (merge {:ref set-ref!

--- a/app/frontend/src/cljs/teet/ui/text_field.cljs
+++ b/app/frontend/src/cljs/teet/ui/text_field.cljs
@@ -38,11 +38,14 @@
 
 (defn input-button-style
   []
+  ^{:pseudo {:hover {:background-color theme-colors/gray-lightest}}}
   {:max-height "42px"
    :position :absolute
    :top "50%"
-   :right 0
-   :transform "translateY(-50%)"})
+   :right "2px"
+   :transform "translateY(-50%)"
+   :padding "1px"
+   :background-color theme-colors/white})
 
 (defn end-icon-style
   []


### PR DESCRIPTION
Improve the input button styling so content doesn't show through it.
Handle stale result if an earlier input's result comes after a later one.