### PR TITLE
TEET-1603: error tooltip

### DIFF
--- a/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
+++ b/app/frontend/src/cljs/teet/asset/cost_items_view.cljs
@@ -317,13 +317,17 @@
                        :label (label attr)
                        :show-empty-selection? true
                        :items (mapv :db/ident (:enum/_attribute attr))
-                       :format-item (comp label rotl)}])
+                       :format-item (comp label rotl)
+                       ;; Show error message as tooltip instead of adding a span, so that input
+                       ;; elements in the grid will stay aligned.
+                       :error-tooltip? true}])
 
                    (= type :db.type/instant)
                    (if locked?
                      [display-input {:label (label attr)
                                      :format fmt/date}]
-                     [date-picker/date-input {:label (label attr)}])
+                     [date-picker/date-input {:label (label attr)
+                                              :error-tooltip? true}])
 
                    ;; Text field
                    :else
@@ -334,7 +338,8 @@
                       {:label (label attr)
                        :read-only? locked?
                        :end-icon (when unit
-                                   (text-field/unit-end-icon unit))}]))]]))]]))])))
+                                   (text-field/unit-end-icon unit))
+                       :error-tooltip? true}]))]]))]]))])))
 
 (defn- attributes
   "Render grid of attributes."

--- a/app/frontend/src/cljs/teet/ui/common.cljs
+++ b/app/frontend/src/cljs/teet/ui/common.cljs
@@ -564,9 +564,13 @@
   error message is displayed.
 
   If msg is nil, the component is returned as is.
-  Otherwise msg must be a map containing :title and :body  for the error message."
-  [{:keys [title body variant icon class] :as msg
-    :or {variant :error}} component]
+  Otherwise msg must be a map containing :title and :body  for the error message.
+  If `hidden?` is true, render the tooltip wrapper without content, to avoid problems when
+  adding/removing the wrapper dynamically.
+  Option `tabIndex` can be used stop the popup wrapper participating in sequential keyboard
+  navigation (default: 0)."
+  [{:keys [title body variant icon class hidden? tabIndex] :as msg
+    :or {variant :error tabIndex 0}} component]
   (r/with-let [hover? (r/atom false)
                anchor-el (r/atom nil)
                set-anchor-el! #(reset! anchor-el %)
@@ -583,17 +587,18 @@
              :on-focus enter!
              :on-blur leave!
              :ref set-anchor-el!
-             :tabIndex 0
+             :tabIndex tabIndex
              :class container-class}
        component
        [Popper {:style {:z-index 1600}                      ;; z-index is not specified for poppers so they by default appear under modals
                 :open @hover?
                 :anchor-el @anchor-el
                 :placement "bottom-start"}
-        [popper-tooltip-content {:variant variant
-                                 :title title
-                                 :body body
-                                 :icon icon}]]])))
+        (when-not hidden?
+          [popper-tooltip-content {:variant variant
+                                   :title title
+                                   :body body
+                                   :icon icon}])]])))
 
 
 (defn portal

--- a/app/frontend/src/cljs/teet/ui/component_demo.cljs
+++ b/app/frontend/src/cljs/teet/ui/component_demo.cljs
@@ -263,9 +263,37 @@
                   :margin "2rem 0"}}
     [select/form-select {:value "et"
                          :label "Language"
+                         :on-change #()
                          :show-empty-selection? true
                          :id "language-select"
                          :name "Language"
+                         :items
+                         [{:value "et" :label "bar"}
+                          {:value "en" :label "baz"}]}]]
+   [:div {:style {:width "50%"
+                  :margin "2rem 0"}}
+    [select/form-select {:value "et"
+                         :label "Language"
+                         :on-change #()
+                         :show-empty-selection? true
+                         :id "language-select-with-error"
+                         :name "Language"
+                         :error true
+                         :error-text "This is an error"
+                         :items
+                         [{:value "et" :label "bar"}
+                          {:value "en" :label "baz"}]}]]
+   [:div {:style {:width "50%"
+                  :margin "2rem 0"}}
+    [select/form-select {:value "et"
+                         :label "Language"
+                         :on-change #()
+                         :show-empty-selection? true
+                         :id "language-select-with-error-tooltip"
+                         :name "Language"
+                         :error true
+                         :error-text "This is an error"
+                         :error-tooltip? true
                          :items
                          [{:value "et" :label "bar"}
                           {:value "en" :label "baz"}]}]]

--- a/app/frontend/src/cljs/teet/ui/component_demo.cljs
+++ b/app/frontend/src/cljs/teet/ui/component_demo.cljs
@@ -25,7 +25,8 @@
             [teet.contract.contract-common :as contract-common]
             [teet.contract.contracts-view :as contracts-view]
             [teet.ui.table :as table]
-            [teet.common.common-styles :as common-styles]))
+            [teet.common.common-styles :as common-styles]
+            [teet.ui.date-picker :as date-picker]))
 
 
 (defrecord TestFileUpload [files])
@@ -268,6 +269,25 @@
 
                                         {:value "bar" :label "Bar"}]}]]])
 
+(defn datepicker-demo []
+  [:section
+   [:div {:style {:display "flex"
+                  :justify-content "space-evenly"}}
+    [date-picker/date-input {:label "Date"
+                             :placeholder "Placeholder"
+                             :on-change #()}]
+    [date-picker/date-input {:label "Date with error label"
+                             :placeholder "Placeholder"
+                             :on-change #()
+                             :error true
+                             :error-text "This is an error"}]
+    [date-picker/date-input {:label "Date with error tooltip"
+                             :placeholder "Placeholder"
+                             :on-change #()
+                             :error true
+                             :error-text "This is an error"
+                             :error-tooltip? true}]]])
+
 (defn- labeled-data-demo []
   [:div
    [ui-common/labeled-data {:label "Label" :data "Some textual data"}]])
@@ -442,6 +462,9 @@
    {:id :select
     :heading "Select"
     :component [select-demo]}
+   {:id :datepicker
+    :heading "Datepicker"
+    :component [datepicker-demo]}
    {:id :labeled-data
     :heading "Labeled data"
     :component [labeled-data-demo]}

--- a/app/frontend/src/cljs/teet/ui/component_demo.cljs
+++ b/app/frontend/src/cljs/teet/ui/component_demo.cljs
@@ -98,6 +98,14 @@
                     :placeholder "Placeholder"
                     :error true
                     :error-text "Form field is required"
+                    :variant :filled}]
+        [TextField {:label "Tekstiä"
+                    :on-change on-change
+                    :value @val
+                    :placeholder "Placeholder"
+                    :error true
+                    :error-text "Form field is required"
+                    :error-tooltip? true
                     :variant :filled}]]
        [Divider]])))
 

--- a/app/frontend/src/cljs/teet/ui/date_picker.cljs
+++ b/app/frontend/src/cljs/teet/ui/date_picker.cljs
@@ -221,7 +221,7 @@
 (defn date-input*
   "Combined text field and date picker component"
   [{:keys [label error value on-change selectable? required placeholder
-            read-only? end start min-date max-date error-text]}]
+            read-only? end start min-date max-date error-text error-tooltip?]}]
   (let [[txt set-txt!] (react/useState "")
         [open? set-open?] (react/useState false)
         [ref set-ref!] (react/useState nil)
@@ -253,6 +253,7 @@
                         :placeholder placeholder
                         :error error
                         :error-text error-text
+                        :error-tooltip? error-tooltip?
                         :required required
                         :variant "outlined"
                         :full-width true

--- a/app/frontend/src/cljs/teet/ui/select.cljs
+++ b/app/frontend/src/cljs/teet/ui/select.cljs
@@ -48,8 +48,8 @@
            {:cursor :default})))
 
 (defn form-select [{:keys [label name id items on-change value format-item label-element
-                           show-label? show-empty-selection? error error-text required empty-selection-label
-                           data-item? read-only? dark-theme?]
+                           show-label? show-empty-selection? error error-text error-tooltip?
+                           required empty-selection-label data-item? read-only? dark-theme?]
                         :or {format-item :label
                              show-label? true
                              data-item? false
@@ -59,39 +59,52 @@
                        (let [val (-> e .-target .-value)]
                          (if (= val "")
                            (on-change nil)
-                           (on-change (nth items (int val))))))]
-    [:label {:for id
-             :class (<class common-styles/input-label-style read-only? dark-theme?)}
-     (when show-label?
-       (if label-element
-         [label-element label (when required [common/required-astrix])]
-         [typography/Text2Bold
-          label (when required
-                        [common/required-astrix])]))
-     [:div {:style {:position :relative}}
-      [:select
-       {:value (or (option-idx value) "")
-        :name name
-        :disabled read-only?
-        :class (<class primary-select-style error read-only?)
-        :required (boolean required)
-        :id (str "links-type-select" id)
-        :on-change (fn [e]
-                     (change-value e))}
-       (when show-empty-selection?
-         [:option {:value "" :label empty-selection-label}])
-       (doall
-        (map-indexed
-         (fn [i item]
-           [:option (merge {:value i
-                            :key i}
-                           (when data-item?
-                             {:data-item (str item)}))
-            (format-item item)])
-         items))]]
-     (when (and error-text error)
-       [:span {:class (<class common-styles/input-error-text-style)}
-        error-text])]))
+                           (on-change (nth items (int val))))))
+        error? (and error error-text)]
+    [common/popper-tooltip (when error-tooltip?
+                             ;; Show error as tooltip instead of label.
+                             {:title error-text
+                              :variant :error
+                              ;; Always add the tootip and wrapper elements, but hide them when
+                              ;; there is no error. This way the input does not lose focus when the
+                              ;; tooltip is added/removed.
+                              :hidden? (not error?)
+                              ;; We don't want the tooltip wrapper to participate in sequential
+                              ;; keyboard navigation. Otherwise we would need to hit tab twice to
+                              ;; reach the input element in the wrapper.
+                              :tabIndex -1})
+     [:label {:for id
+              :class (<class common-styles/input-label-style read-only? dark-theme?)}
+      (when show-label?
+        (if label-element
+          [label-element label (when required [common/required-astrix])]
+          [typography/Text2Bold
+           label (when required
+                   [common/required-astrix])]))
+      [:div {:style {:position :relative}}
+       [:select
+        {:value (or (option-idx value) "")
+         :name name
+         :disabled read-only?
+         :class (<class primary-select-style error read-only?)
+         :required (boolean required)
+         :id (str "links-type-select" id)
+         :on-change (fn [e]
+                      (change-value e))}
+        (when show-empty-selection?
+          [:option {:value "" :label empty-selection-label}])
+        (doall
+          (map-indexed
+            (fn [i item]
+              [:option (merge {:value i
+                               :key i}
+                              (when data-item?
+                                {:data-item (str item)}))
+               (format-item item)])
+            items))]]
+      (when (and error? (not error-tooltip?))
+        [:span {:class (<class common-styles/input-error-text-style)}
+         error-text])]]))
 
 ;; TODO this needs better styles and better dropdown menu
 

--- a/app/frontend/src/cljs/teet/ui/text_field.cljs
+++ b/app/frontend/src/cljs/teet/ui/text_field.cljs
@@ -89,55 +89,69 @@
 (defn TextField
   [{:keys [label id type error style input-button-icon read-only? inline?
            input-button-click required input-style dark-theme?
-           multiline error-text input-class start-icon
+           multiline error-text error-tooltip? input-class start-icon
            maxrows rows hide-label? end-icon label-element]
     :as props
     :or {rows 2}} & _children]
   (let [element (if multiline
                   :textarea
-                  :input)]
-    [:label {:for id
-             :class (<class common-styles/input-label-style read-only? dark-theme?)
-             :style style}
-     (when-not hide-label?
-       (if label-element
-         [label-element label (when required [common/required-astrix])]
-         [typography/Text2Bold
-          label (when required
-                  [common/required-astrix])]))
-     [:div {:style {:position :relative
-                    :display (if inline? :inline-block :block)}}
-      (when start-icon
-        [start-icon {:color :primary
-                     :class (<class start-icon-style)}])
-      [element (merge
-                 (select-keys props
-                              [:on-change :lang :on-focus :auto-complete
-                               :step :on-key-down :disabled :min :max :type :ref
-                               :required :id :on-blur :placeholder :pattern])
-                 {:value (or (:value props) "")
-                  :style input-style
-                  :class (herb/join input-class
-                                    (<class input-field-style
-                                            error
-                                            multiline
-                                            read-only?
-                                            (boolean start-icon)
-                                            (boolean end-icon)
-                                            type))}
-                 (when read-only?
-                   {:disabled true})
-                 (when multiline
-                   {:rows rows
-                    :maxrows maxrows}))]
-      (when end-icon
-        end-icon)
-      (when (and input-button-click input-button-icon)
-        [IconButton {:on-click input-button-click
-                     :disable-ripple true
-                     :color :primary
-                     :class (<class input-button-style)}
-         [input-button-icon]])]
-     (when (and error error-text)
-       [:span {:class (<class common-styles/input-error-text-style)}
-        error-text])]))
+                  :input)
+        error? (and error error-text)]
+    [common/popper-tooltip (when error-tooltip?
+                             ;; Show error as tooltip instead of label.
+                             {:title error-text
+                              :variant :error
+                              ;; Always add the tootip and wrapper elements, but hide them when
+                              ;; there is no error. This way the input does not lose focus when the
+                              ;; tooltip is added/removed.
+                              :hidden? (not error?)
+                              ;; We don't want the tooltip wrapper to participate in sequential
+                              ;; keyboard navigation. Otherwise we would need to hit tab twice to
+                              ;; reach the input element in the wrapper.
+                              :tabIndex -1})
+     [:label {:for id
+              :class (<class common-styles/input-label-style read-only? dark-theme?)
+              :style style}
+      (when-not hide-label?
+        (if label-element
+          [label-element label (when required [common/required-astrix])]
+          [typography/Text2Bold
+           label (when required
+                   [common/required-astrix])]))
+      [:div {:style {:position :relative
+                     :display (if inline? :inline-block :block)}}
+       (when start-icon
+         [start-icon {:color :primary
+                      :class (<class start-icon-style)}])
+       [element (merge
+                  (select-keys props
+                               [:on-change :lang :on-focus :auto-complete
+                                :step :on-key-down :disabled :min :max :type :ref
+                                :required :id :on-blur :placeholder :pattern])
+                  {:value (or (:value props) "")
+                   :style input-style
+                   :class (herb/join input-class
+                                     (<class input-field-style
+                                             error
+                                             multiline
+                                             read-only?
+                                             (boolean start-icon)
+                                             (boolean end-icon)
+                                             type))}
+                  (when read-only?
+                    {:disabled true})
+                  (when multiline
+                    {:rows rows
+                     :maxrows maxrows}))]
+       (when end-icon
+         end-icon)
+       (when (and input-button-click input-button-icon)
+         [IconButton {:on-click input-button-click
+                      :disable-ripple true
+                      :color :primary
+                      :class (<class input-button-style)}
+          [input-button-icon]])]
+      (when (and error? (not error-tooltip?))
+        ;; Show error label instead of tooltip (default).
+        [:span {:class (<class common-styles/input-error-text-style)}
+         error-text])]]))


### PR DESCRIPTION
- Add option to show error as tooltip instead of label for `TextField`, `form-select` and `date-input`
- Show error message tooltips for cost-item attributes grid, so that input elements in the grid will stay aligned