### PR TITLE
Material fixes

### DIFF
--- a/app/frontend/src/cljs/teet/project/project_menu.cljs
+++ b/app/frontend/src/cljs/teet/project/project_menu.cljs
@@ -74,7 +74,7 @@
     :hotkey "8"
     :feature-flag :cost-items
     :authorization :cost-items/cost-items
-    :match-pages #{:cost-item :cost-items :cost-items-totals}}
+    :match-pages #{:cost-item :cost-items :cost-items-totals :materials-and-products}}
    {:name :cooperation
     :label [:project :tabs :cooperation]
     :navigate {:page :cooperation}
@@ -128,7 +128,7 @@
          [:span (tr label)]]
         [:div {:class (<class project-style/project-view-selection-item-hotkey)} (tr [:common :hotkey] {:key hotkey})]]))))
 
-(defn project-menu [_e! _app project _dark-theme?]
+(defn project-menu [_e! _app _project _dark-theme?]
   (let [open? (r/atom false)
         anchor-el (atom nil)
         toggle-open! #(do
@@ -137,7 +137,7 @@
         set-anchor! #(reset! anchor-el %)]
     (common/component
      (hotkeys/hotkey "Q" toggle-open!)
-     (fn [e! {:keys [params query] :as app} project dark-theme?]
+     (fn [e! app project dark-theme?]
        (let [{tab-name :name
               tab-label :label} (active-tab app)]
          [:div {:class (<class project-style/project-tab-container dark-theme?)}


### PR DESCRIPTION
- Change "Activities" to "Cost items" in the tab selector of Materials and products view
- Don't show "Components", ie. the empty component tree if the component has materials