### PR TITLE
TEET-1429 Move project menu next to project name

### DIFF
--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -200,6 +200,7 @@
   :date "Date",
   :log-out "Log out",
   :back-to-project "Back to project",
+  :project-menu "Project menu",
   :now "Now",
   :construction-phase "Phase",
   :general "General",

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -197,6 +197,7 @@
   :date "kuupäev",
   :log-out "Väljun",
   :back-to-project "Tagasi projekti",
+  :project-menu "Projekti menüü",
   :now "Nüüd",
   :construction-phase "Ehitusetapp",
   :general "Üldine",

--- a/app/frontend/src/cljs/teet/project/project_navigator_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_navigator_view.cljs
@@ -418,15 +418,19 @@
                                           (select-keys project [:thk.project/id]))}})])
 
 (defn project-header
-  ([project]
-   (project-header project nil))
-  ([project export-menu-items]
+  ([e! app project]
+   (project-header e! app  project nil))
+  ([e! app project export-menu-items]
    (let [thk-url (project-info/thk-url project)]
      [:div {:class (<class project-header-style)}
       [:div {:style {:display :flex
                      :justify-content :space-between}}
-       [typography/Heading1 {:style {:margin-bottom 0}}
-        (project-model/get-column project :thk.project/project-name)]
+       [:div {:style {:display :flex
+                      :justify-content :flex-start}}
+        [project-menu/project-menu e! app project]
+        [typography/Heading1 {:style {:margin-bottom 0
+                                      :margin-left "1rem"}}
+         (project-model/get-column project :thk.project/project-name)]]
        [:div {:style {:display :flex
                       :align-items :center}}
         [common/context-menu
@@ -457,7 +461,7 @@
     [project-context/provide
      project
      [:<>
-      [project-header project export-menu-items]
+      [project-header e! app project export-menu-items]
       [:div.project-navigator-with-content {:class (<class project-style/page-container)}
        [project-navigator-dialogs opts]
        [Paper {:class (<class task-style/task-page-paper-style)}
@@ -468,7 +472,7 @@
                 :md nav-w
                 :xs 12
                 :class (<class navigation-style/navigator-left-panel-style)}
-          [project-menu/project-menu e! app project true]
+          [project-menu/project-tab-header e! app project true]
           [project-task-navigator e! project app true]]
          [Grid {:item true
                 :xs 12

--- a/app/frontend/src/cljs/teet/project/project_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_view.cljs
@@ -128,7 +128,7 @@
           show-opinion-export? (and (= (get-in app [:query :tab]) "land")
                                     (common-controller/feature-enabled? :land-owner-opinions))]
       [:div {:class (<class project-style/project-page-structure)}
-       [project-navigator-view/project-header project
+       [project-navigator-view/project-header e! app project
         (when show-opinion-export?
           [{:id "owner-opinion-export"
             :label (tr [:land-owner-opinion :opinion-export])
@@ -686,7 +686,7 @@
       ^{:key "project-view"}
       [project-page-structure e! app project
        (merge {:key (name tab-name)
-               :header [project-menu/project-menu e! app project false]
+               :header [project-menu/project-tab-header e! app project false]
                :body [project-menu/project-tab-content tab-name e! app project]
                :map-settings {:layers (or (:layers tab)
                                           #{:thk-project :surveys})}
@@ -714,7 +714,7 @@
     [project-context/provide
      project
      [:<>
-      [project-navigator-view/project-header project export-menu-items]
+      [project-navigator-view/project-header e! app project export-menu-items]
       [:div.project-navigator-with-content {:class (<class project-style/page-container)}
        [Paper {:class (<class task-style/task-page-paper-style)}
         [Grid {:container true
@@ -724,7 +724,7 @@
                 :xs 12
                 :md navigator-w
                 :class (<class navigation-style/navigator-left-panel-style)}
-          [project-menu/project-menu e! app project true]
+          [project-menu/project-tab-header e! app project true]
           (or left-panel
               [project-navigator-view/project-navigator e! project app
                (merge {:dark-theme? true


### PR DESCRIPTION
- Split project-menu into project-tab-header and project-menu
- Change IconButton to button-primary with icon and text
- Always use day theme for project menu because of the new location