### PR TITLE
TEET-1429 project menu mobile

### DIFF
--- a/app/common/resources/public/language/en.edn
+++ b/app/common/resources/public/language/en.edn
@@ -195,6 +195,7 @@
   :comments-for "Comments for {file-name}:"},
  :common
  {:hide-menu "Hide menu",
+  :project-menu "Project menu",
   :send-feedback "Send feedback",
   :forbidden-explanation
   "You have tried to access a resource you're not authorized to access.",

--- a/app/common/resources/public/language/et.edn
+++ b/app/common/resources/public/language/et.edn
@@ -193,6 +193,7 @@
   :comments-for "{file-name} märkused"},
  :common
  {:hide-menu "Peidan menüü",
+  :project-menu "Projekti menüü",
   :send-feedback "Saadan tagasisidet",
   :forbidden-explanation "Puuduvad juurdepääsu õigused",
   :select-files "Valin fail(id)",

--- a/app/common/src/cljc/teet/util/collection.cljc
+++ b/app/common/src/cljc/teet/util/collection.cljc
@@ -310,3 +310,19 @@
                  sub-path)))))]
 
     (containing [] form)))
+
+(defn combine-and-flatten
+  "Combines two collections/values and flattens the result.
+  ```
+(combine-and-flatten [1 2] 3)
+=> (1 2 3)
+(combine-and-flatten [1 2] [3 4])
+=> (1 2 3 4)
+(combine-and-flatten 1 2)
+=> (1 2)
+(combine-and-flatten 1 [2 3])
+=> (1 2 3)
+  ```"
+  [to from]
+  (->> (into [to] [from])
+       flatten))

--- a/app/frontend/src/cljs/teet/common/common_styles.cljs
+++ b/app/frontend/src/cljs/teet/common/common_styles.cljs
@@ -579,6 +579,10 @@
   {:overflow :hidden
    :text-overflow :ellipsis})
 
+(defn truncate-text []
+  (merge (overflow-ellipsis)
+         (white-space-nowrap)))
+
 (defn flex-shrink-no-wrap
   []
   {:display :flex

--- a/app/frontend/src/cljs/teet/main.cljs
+++ b/app/frontend/src/cljs/teet/main.cljs
@@ -65,7 +65,7 @@
     (let [{:keys [page]} (page-and-title e! app)]      
       [:<>
        [drag/drag-handler e!]
-       [navigation-view/header e!
+       [navigation-view/header e! app
         {:open? nav-open?
          :page (:page app)
          :quick-search (:quick-search app)

--- a/app/frontend/src/cljs/teet/navigation/navigation_style.cljs
+++ b/app/frontend/src/cljs/teet/navigation/navigation_style.cljs
@@ -60,6 +60,7 @@
 (defn appbar []
   (with-meta
     {:display :flex
+     :flex-direction :column
       :top 0
       :bottom :auto
       :background-color theme-colors/white

--- a/app/frontend/src/cljs/teet/navigation/navigation_view.cljs
+++ b/app/frontend/src/cljs/teet/navigation/navigation_view.cljs
@@ -22,7 +22,8 @@
             [teet.ui.typography :as typography]
             [teet.user.user-model :as user-model]
             [teet.ui.events :as events]
-            [teet.common.common-styles :as common-styles]))
+            [teet.common.common-styles :as common-styles]
+            [teet.project.project-view :as project-view]))
 
 
 (def uri-quote (fnil js/encodeURIComponent "(nil)"))
@@ -333,35 +334,37 @@
      [header-extra-panel e! user {:quick-search quick-search} extra-panel]]]])
 
 (defn header
-  [e! {:keys [open? page quick-search url extra-panel extra-panel-open?]} user]
+  [e! app {:keys [open? page quick-search url extra-panel extra-panel-open?]} user]
   [:<>
    [ClickAwayListener {:on-click-away #(e! (navigation-controller/->CloseExtraPanel))}
-    [AppBar {:position "sticky"
-             :className (herb/join (<class navigation-style/appbar)
-                                   (<class navigation-style/appbar-position open?))}
-     [Toolbar {:className (herb/join (<class navigation-style/toolbar))}
-      [buttons/stand-alone-icon-button
-       {:class [(<class responsivity-styles/mobile-navigation-button)]
-        :icon [icons/navigation-menu {:color :primary}]
-        :on-click #(e! (navigation-controller/->ToggleDrawer))}]
-      [:div {:class (<class navigation-style/logo-style)}
-       [navigation-logo/maanteeamet-logo false]]
-      [:div {:class (<class responsivity-styles/desktop-only-style
-                            {:position   :relative
-                             :flex-grow  1
-                             :flex-basis "400px"
-                             :display    :block}
-                            {:display :none})}
-       [search-view/quick-search
-        e!
-        quick-search
-        (<class navigation-style/search-input-style)]]
-      [navigation-header-links e! user url]]
-     [header-extra-panel-container e!
-      {:user user
-       :quick-search quick-search
-       :extra-panel extra-panel
-       :extra-panel-open? extra-panel-open?}]]]
+    [AppBar {:position "sticky"}
+     [:div {:className (herb/join (<class navigation-style/appbar)
+                                  (<class navigation-style/appbar-position open?))}
+      [Toolbar {:className (herb/join (<class navigation-style/toolbar))}
+       [buttons/stand-alone-icon-button
+        {:class [(<class responsivity-styles/mobile-navigation-button)]
+         :icon [icons/navigation-menu {:color :primary}]
+         :on-click #(e! (navigation-controller/->ToggleDrawer))}]
+       [:div {:class (<class navigation-style/logo-style)}
+        [navigation-logo/maanteeamet-logo false]]
+       [:div {:class (<class responsivity-styles/desktop-only-style
+                             {:position :relative
+                              :flex-grow 1
+                              :flex-basis "400px"
+                              :display :block}
+                             {:display :none})}
+        [search-view/quick-search
+         e!
+         quick-search
+         (<class navigation-style/search-input-style)]]
+       [navigation-header-links e! user url]]
+      [header-extra-panel-container e!
+       {:user user
+        :quick-search quick-search
+        :extra-panel extra-panel
+        :extra-panel-open? extra-panel-open?}]]
+     ;; Header extension for project views (mobile)
+     [project-view/project-menu-header e! app open?]]]
 
    (if (responsivity-styles/mobile?)
      [Drawer {:classes {"paperAnchorDockedLeft"

--- a/app/frontend/src/cljs/teet/navigation/navigation_view.cljs
+++ b/app/frontend/src/cljs/teet/navigation/navigation_view.cljs
@@ -366,21 +366,22 @@
      ;; Header extension for project views (mobile)
      [project-view/project-menu-header e! app open?]]]
 
-   [Drawer {:classes {"paperAnchorDockedLeft"
-                      (<class navigation-style/mobile-drawer open?)}
-            :variant "temporary"
-            :on-close (e! navigation-controller/->CloseDrawer)
-            :anchor "left"
-            :open open?
-            :disablePortal true}
-    [page-listing e! open? user page]]
-   [Drawer {:classes {"paperAnchorDockedLeft"
-                      (<class navigation-style/desktop-drawer open?)}
-            :variant "permanent"
-            :on-close (e! navigation-controller/->CloseDrawer)
-            :anchor "left"
-            :open open?}
-    [page-listing e! open? user page]]])
+   (if (responsivity-styles/mobile?)
+     [Drawer {:classes {"paperAnchorDockedLeft"
+                        (<class navigation-style/mobile-drawer open?)}
+              :variant "temporary"
+              :on-close (e! navigation-controller/->CloseDrawer)
+              :anchor "left"
+              :open open?
+              :disablePortal true}
+      [page-listing e! open? user page]]
+     [Drawer {:classes {"paperAnchorDockedLeft"
+                        (<class navigation-style/desktop-drawer open?)}
+              :variant "permanent"
+              :on-close (e! navigation-controller/->CloseDrawer)
+              :anchor "left"
+              :open open?}
+      [page-listing e! open? user page]])])
 
 (defn login-header
   [e! {:keys [url extra-panel extra-panel-open?] :as _app}]

--- a/app/frontend/src/cljs/teet/navigation/navigation_view.cljs
+++ b/app/frontend/src/cljs/teet/navigation/navigation_view.cljs
@@ -366,22 +366,21 @@
      ;; Header extension for project views (mobile)
      [project-view/project-menu-header e! app open?]]]
 
-   (if (responsivity-styles/mobile?)
-     [Drawer {:classes {"paperAnchorDockedLeft"
-                        (<class navigation-style/mobile-drawer open?)}
-              :variant "temporary"
-              :on-close (e! navigation-controller/->CloseDrawer)
-              :anchor "left"
-              :open open?
-              :disablePortal true}
-      [page-listing e! open? user page]]
-     [Drawer {:classes {"paperAnchorDockedLeft"
-                        (<class navigation-style/desktop-drawer open?)}
-              :variant "permanent"
-              :on-close (e! navigation-controller/->CloseDrawer)
-              :anchor "left"
-              :open open?}
-      [page-listing e! open? user page]])])
+   [Drawer {:classes {"paperAnchorDockedLeft"
+                      (<class navigation-style/mobile-drawer open?)}
+            :variant "temporary"
+            :on-close (e! navigation-controller/->CloseDrawer)
+            :anchor "left"
+            :open open?
+            :disablePortal true}
+    [page-listing e! open? user page]]
+   [Drawer {:classes {"paperAnchorDockedLeft"
+                      (<class navigation-style/desktop-drawer open?)}
+            :variant "permanent"
+            :on-close (e! navigation-controller/->CloseDrawer)
+            :anchor "left"
+            :open open?}
+    [page-listing e! open? user page]]])
 
 (defn login-header
   [e! {:keys [url extra-panel extra-panel-open?] :as _app}]

--- a/app/frontend/src/cljs/teet/project/project_controller.cljs
+++ b/app/frontend/src/cljs/teet/project/project_controller.cljs
@@ -130,6 +130,17 @@
 
 (defrecord FetchFeatureCandidatesResponse [candidate-type response])
 
+(defmulti app->project
+  "Get project map from app state.
+  Currently the default implementation works for all /projects/* pages, but this can be overridden
+  for new pages if needed."
+  (fn [app] (:page app)))
+
+(defmethod app->project :default [app]
+  (or (and (common-controller/page-state app :thk.project/id)
+           (common-controller/page-state app))
+      (common-controller/page-state app :project)))
+
 (defn datasource-ids-by-type
   [app type]
   (case type

--- a/app/frontend/src/cljs/teet/project/project_menu.cljs
+++ b/app/frontend/src/cljs/teet/project/project_menu.cljs
@@ -146,7 +146,7 @@
         anchor-el (atom nil)
         toggle-open! #(do
                         (swap! open? not)
-                        (.blur @anchor-el))
+                        (some-> @anchor-el .blur))
         set-anchor! #(reset! anchor-el %)]
     (common/component
       (hotkeys/hotkey "Q" toggle-open!)

--- a/app/frontend/src/cljs/teet/project/project_menu.cljs
+++ b/app/frontend/src/cljs/teet/project/project_menu.cljs
@@ -156,12 +156,13 @@
           [:<>
            (if (responsivity-styles/mobile?)
              [buttons/stand-alone-icon-button
-              {:class ["project-menu" (<class responsivity-styles/mobile-navigation-button)]
+              {:data-cy "project-menu"
+               :class (<class responsivity-styles/mobile-navigation-button)
                :icon [icons/navigation-menu {:color :primary}]
                :on-click toggle-open!
                :ref set-anchor!}]
              [buttons/button-primary
-              {:class "project-menu"
+              {:data-cy "project-menu"
                :size "small"
                :start-icon (r/as-element [icons/navigation-menu])
                :on-click toggle-open!

--- a/app/frontend/src/cljs/teet/project/project_menu.cljs
+++ b/app/frontend/src/cljs/teet/project/project_menu.cljs
@@ -17,7 +17,8 @@
             [teet.theme.theme-colors :as theme-colors]
             [teet.authorization.authorization-check :as authorization-check]
             [teet.ui.url :as url]
-            [teet.ui.buttons :as buttons]))
+            [teet.ui.buttons :as buttons]
+            [teet.common.responsivity-styles :as responsivity-styles]))
 
 ;; Define multimethods that different views can implement to hook into
 ;; the project menu system.
@@ -168,7 +169,8 @@
               (tr [:common :project-menu])])
            [Popper {:open @open?
                     :anchor-el @anchor-el
-                    :classes {:paper (<class project-style/project-view-selection-menu)}
+                    :classes #js {:paper (<class project-style/project-view-selection-menu)}
+                    :style {:z-index 1200}
                     :placement "bottom-start"}
             (project-context/consume
               (fn [{project-id :thk.project/id}]

--- a/app/frontend/src/cljs/teet/project/project_menu.cljs
+++ b/app/frontend/src/cljs/teet/project/project_menu.cljs
@@ -153,13 +153,19 @@
       (fn [e! app project]
         (let [{tab-name :name} (active-tab app)]
           [:<>
-           [buttons/button-primary
-            {:class "project-menu"
-             :size "small"
-             :start-icon (r/as-element [icons/navigation-menu])
-             :on-click toggle-open!
-             :ref set-anchor!}
-            (tr [:common :project-menu])]
+           (if (responsivity-styles/mobile?)
+             [buttons/stand-alone-icon-button
+              {:class ["project-menu" (<class responsivity-styles/mobile-navigation-button)]
+               :icon [icons/navigation-menu {:color :primary}]
+               :on-click toggle-open!
+               :ref set-anchor!}]
+             [buttons/button-primary
+              {:class "project-menu"
+               :size "small"
+               :start-icon (r/as-element [icons/navigation-menu])
+               :on-click toggle-open!
+               :ref set-anchor!}
+              (tr [:common :project-menu])])
            [Popper {:open @open?
                     :anchor-el @anchor-el
                     :classes {:paper (<class project-style/project-view-selection-menu)}

--- a/app/frontend/src/cljs/teet/project/project_navigator_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_navigator_view.cljs
@@ -427,7 +427,8 @@
        (when-not (responsivity-styles/mobile?)
          [:div {:class (<class common-styles/flex-row-center)}
           [project-menu/project-menu e! app project]
-          [typography/TextBold {:style {:text-transform :uppercase}
+          [typography/TextBold {:data-cy "project-header"
+                                :style {:text-transform :uppercase}
                                 :class (<class common-styles/margin-left 0.5)}
            (project-model/get-column project :thk.project/project-name)]])
        [:div {:style {:display :flex

--- a/app/frontend/src/cljs/teet/project/project_navigator_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_navigator_view.cljs
@@ -423,14 +423,13 @@
   ([e! app project export-menu-items]
    (let [thk-url (project-info/thk-url project)]
      [:div {:class (<class project-header-style)}
-      [:div {:style {:display :flex
-                     :justify-content :space-between}}
-       [:div {:style {:display :flex
-                      :justify-content :flex-start}}
-        [project-menu/project-menu e! app project]
-        [typography/Heading1 {:style {:margin-bottom 0
-                                      :margin-left "1rem"}}
-         (project-model/get-column project :thk.project/project-name)]]
+      [:div {:class (<class common-styles/flex-row-space-between)}
+       (when-not (responsivity-styles/mobile?)
+         [:div {:class (<class common-styles/flex-row-center)}
+          [project-menu/project-menu e! app project]
+          [typography/TextBold {:style {:text-transform :uppercase}
+                                :class (<class common-styles/margin-left 0.5)}
+           (project-model/get-column project :thk.project/project-name)]])
        [:div {:style {:display :flex
                       :align-items :center}}
         [common/context-menu

--- a/app/frontend/src/cljs/teet/project/project_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_view.cljs
@@ -22,12 +22,12 @@
             [teet.ui.format :as format]
             [teet.ui.icons :as icons]
             [teet.ui.itemlist :as itemlist]
-            [teet.ui.material-ui :refer [Paper Divider Collapse Badge Grid ButtonBase]]
+            [teet.ui.material-ui :refer [Paper Divider Collapse Badge Grid ButtonBase Toolbar]]
             [teet.ui.panels :as panels]
             [teet.ui.project-context :as project-context]
             [teet.ui.select :as select]
             [teet.ui.text-field :refer [TextField]]
-            [teet.ui.typography :refer [Heading1 Heading3] :as typography]
+            [teet.ui.typography :refer [Heading1 Heading3 TextBold] :as typography]
             [teet.ui.url :as url]
             [teet.ui.util :refer [mapc] :as util]
             [teet.util.collection :as cu]
@@ -50,7 +50,8 @@
             [teet.navigation.navigation-style :as navigation-style]
             [teet.contract.contract-style :as contract-style]
             [teet.contract.contract-status :as contract-status]
-            [teet.contract.contract-model :as contract-model]))
+            [teet.contract.contract-model :as contract-model]
+            [teet.common.responsivity-styles :as responsivity-styles]))
 
 (defn contract-info
   [{:thk.contract/keys [status] :as contract}]
@@ -700,6 +701,22 @@
    [:<>
     [project-navigator-view/project-navigator-dialogs {:e! e! :app app :project project}]
     [project-view e! app project]]])
+
+(defn project-menu-header
+  [e! app open?]
+  (when-let [project (project-controller/app->project app)]
+    [project-context/provide
+     project
+     (if (responsivity-styles/mobile?)
+       [:div {:className (herb/join (<class navigation-style/appbar)
+                                    (<class navigation-style/appbar-position open?))}
+        [Toolbar {:className (herb/join (<class navigation-style/toolbar))
+                  :style {:display "flex"
+                          :justify-content :space-between}}
+         [TextBold {:style {:text-transform :uppercase}
+                    :class (<class common-styles/margin-left 0.5)}
+          (:thk.project/name project)]
+         [project-menu/project-menu e! app (get-in app [:route :project])]]])]))
 
 (defn project-full-page-structure
   "Structure for project pages that don't have map, but have

--- a/app/frontend/src/cljs/teet/project/project_view.cljs
+++ b/app/frontend/src/cljs/teet/project/project_view.cljs
@@ -713,8 +713,9 @@
         [Toolbar {:className (herb/join (<class navigation-style/toolbar))
                   :style {:display "flex"
                           :justify-content :space-between}}
-         [TextBold {:style {:text-transform :uppercase}
-                    :class (<class common-styles/margin-left 0.5)}
+         [TextBold {:data-cy "project-header"
+                    :style {:text-transform :uppercase}
+                    :class (<class common-styles/truncate-text)}
           (:thk.project/name project)]
          [project-menu/project-menu e! app (get-in app [:route :project])]]])]))
 

--- a/app/frontend/src/cljs/teet/ui/buttons.cljs
+++ b/app/frontend/src/cljs/teet/ui/buttons.cljs
@@ -130,11 +130,12 @@
                              :type      :button}))
 
 (defn stand-alone-icon-button
-  [{:keys [id on-click icon class href]}]
+  [{:keys [id on-click icon class href ref]}]
   [IconButton {:size :small
                :class (conj class (<class common-styles/stand-alone-icon-button-style))
                :on-click on-click
                :href href
+               :ref ref
                :id id
                }
    icon])

--- a/app/frontend/src/cljs/teet/ui/buttons.cljs
+++ b/app/frontend/src/cljs/teet/ui/buttons.cljs
@@ -10,7 +10,8 @@
             [taoensso.timbre :as log]
             [reagent.core :as r]
             [teet.ui.panels :as panels]
-            [teet.common.common-styles :as common-styles]))
+            [teet.common.common-styles :as common-styles]
+            [teet.util.collection :as collection]))
 
 (defn- white-button-style
   []
@@ -132,12 +133,13 @@
 (defn stand-alone-icon-button
   [{:keys [id on-click icon class href ref]}]
   [IconButton {:size :small
-               :class (conj class (<class common-styles/stand-alone-icon-button-style))
+               :class (collection/combine-and-flatten
+                        class
+                        (<class common-styles/stand-alone-icon-button-style))
                :on-click on-click
                :href href
                :ref ref
-               :id id
-               }
+               :id id}
    icon])
 
 (defn link-button-with-icon

--- a/app/frontend/src/cljs/teet/ui/hotkeys.cljs
+++ b/app/frontend/src/cljs/teet/ui/hotkeys.cljs
@@ -35,10 +35,13 @@
    {:component-did-mount (fn
                            [this]
                            (update-or-assoc-hotkey-registry this key on-key-press focus-element-name))
-    :component-will-unmount #(swap! hotkey-registry update key (fn [key-handlers]
-                                                                 (if (seq key-handlers)
-                                                                   (pop key-handlers)
-                                                                   key-handlers)))
+    :component-will-unmount #(swap! hotkey-registry update key
+                                    (fn [key-handlers]
+                                      (vec
+                                        ;; Remove handler by identity instead of popping, so that
+                                        ;; order does not matter when there are multiple handlers.
+                                        (remove (fn [h] (= h on-key-press))
+                                                key-handlers))))
     :component-will-receive-props (fn
                                     [this new-argv]
                                     (let [current-props (reagent/props this)

--- a/ci/browser-tests/cypress/integration/cooperation.ci.spec.js
+++ b/ci/browser-tests/cypress/integration/cooperation.ci.spec.js
@@ -36,7 +36,7 @@ context('Cooperation', function() {
         cy.visit("#/projects/"+projectId)
 
         // open menu and select cooperation
-        cy.get("button.project-menu").click({force: true})
+        cy.get("[data-cy='project-menu']").click({force: true})
         cy.get("li.project-menu-item-cooperation").click({force: true})
 
         cy.get(".cooperation-overview-page")

--- a/ci/browser-tests/cypress/integration/land_owner_opinion.ci.spec.js
+++ b/ci/browser-tests/cypress/integration/land_owner_opinion.ci.spec.js
@@ -45,7 +45,7 @@ context('Land owner opinions', function() {
 
     function navigateToProjectLand(projectId) {
         cy.visit("#/projects/"+projectId);
-        cy.get("button.project-menu").click({force: true});
+        cy.get("[data-cy='project-menu']").click({force: true});
         cy.get("li#navigation-item-land").click({force: true})
 
     }

--- a/ci/browser-tests/cypress/integration/land_section.spec.js
+++ b/ci/browser-tests/cypress/integration/land_section.spec.js
@@ -16,7 +16,7 @@ context('Land section', () => {
     cy.contains("Kõik projektid").click();
     cy.get('thead > tr > th:nth-child(1) > label > div > input').type("aruvalla");
     cy.get("p").contains("Aruvalla").click();
-    cy.get("button.project-menu").click();
+    cy.get("[data-cy='project-menu']").click();
     cy.get("li.MuiButtonBase-root:nth-child(6) > div:nth-child(1)").click();
     cy.contains("Vaatan omanike andmeid", {timeout: 120000}).click();
     cy.contains("Omanikud ja omandiosad");

--- a/ci/browser-tests/cypress/integration/task.ci.spec.js
+++ b/ci/browser-tests/cypress/integration/task.ci.spec.js
@@ -12,7 +12,7 @@ describe("Task view", function() {
     it("carla can't delete task", function() {
         cy.dummyLogin("Carla")
         cy.visit(this.taskURL)
-        cy.get("h1").contains("TASK TESTING")
+        cy.get("[data-cy='project-header']").contains("TASK TESTING")
         cy.get("div.task-page")
         cy.get(".task-header button").should("not.exist")
     })
@@ -20,7 +20,7 @@ describe("Task view", function() {
     it("Danny can edit task", function() {
         cy.dummyLogin("Danny")
         cy.visit(this.taskURL)
-        cy.get("h1").contains("TASK TESTING")
+        cy.get("[data-cy='project-header']").contains("TASK TESTING")
         cy.get("div.task-page")
         cy.get(".task-header button").click()
         cy.get(".edit-task-form")

--- a/ci/browser-tests/cypress/support/commands.js
+++ b/ci/browser-tests/cypress/support/commands.js
@@ -109,7 +109,7 @@ Cypress.Commands.add("projectByName", (projectName) => {
   cy.get("td").contains(projectName).click()
 
   // check project page is rendered
-  cy.get("h1").contains(projectName)
+  cy.get("[data-cy='project-header']").contains(projectName)
 })
 
 Cypress.Commands.add("backendCommand", (commandName, payload) => {


### PR DESCRIPTION
- Add extra header in app bar for project views on mobile
- Extra header contains project name and project menu
- Project name and menu are not shown in page content for mobile
- Remove hotkey handler by identity instead of popping