### PR TITLE
TEET-1857 Contracts edit- Unauthorized users should not see "Edit" button

### DIFF
--- a/app/frontend/src/cljs/teet/contract/contract_view.cljs
+++ b/app/frontend/src/cljs/teet/contract/contract_view.cljs
@@ -1,26 +1,21 @@
 (ns teet.contract.contract-view
   (:require [teet.common.common-styles :as common-styles]
             [herb.core :refer [<class] :as herb]
+            [teet.authorization.authorization-check :as authorization-check]
             [teet.ui.url :as url]
-            [teet.ui.icons :as icons]
             [teet.ui.form :as form]
             [teet.ui.buttons :as buttons]
             [teet.ui.text-field :as text-field :refer [TextField]]
-            [reagent.core :as r]
             teet.contract.contract-spec
             [teet.localization :refer [tr]]
             [teet.ui.date-picker :as date-picker]
             [teet.ui.select :as select]
             [teet.common.common-controller :as common-controller]
-            [teet.ui.material-ui :refer [MenuList MenuItem
-                                         IconButton ClickAwayListener Paper
-                                         Popper]]
             [teet.contract.contract-model :as contract-model]
             [teet.ui.typography :as typography]
             [teet.contract.contract-style :as contract-style]
             [teet.ui.table :as table]
             [teet.contract.contract-common :as contract-common]
-            [clojure.string :as str]
             [teet.contract.contract-status :as contract-status]))
 
 (defn target-table
@@ -113,14 +108,16 @@
      [:div {:class (herb/join (<class common-styles/flex-row-w100-space-between-center)
                               (<class common-styles/margin-bottom 2))}
       [typography/Heading1 (tr [:contract :contract-information-heading])]
-      [form/form-modal-button {:modal-title (tr [:contract :edit-contract])
-                               :max-width "sm"
-                               :button-component
-                               [buttons/button-secondary {}
-                                (tr [:buttons :edit])]
+      [authorization-check/when-authorized :thk.contract/edit-contract-details
+       contract
+       [form/form-modal-button {:modal-title (tr [:contract :edit-contract])
+                                :max-width "sm"
+                                :button-component
+                                [buttons/button-secondary {}
+                                 (tr [:buttons :edit])]
 
-                               :form-component [edit-contract-form e!]
-                               :form-value (select-keys contract contract-model/contract-form-keys)}]]
+                                :form-component [edit-contract-form e!]
+                                :form-value (select-keys contract contract-model/contract-form-keys)}]]]
      [contract-common/contract-information-row contract]]
     (let [related-contracts (filter
                               #(not (= (:db/id %) (:db/id contract)))


### PR DESCRIPTION
This PR wraps the button inside a `when-authorized` component.