### PR TITLE
TEET-1429 search field visibility fix

### DIFF
--- a/app/frontend/src/cljs/teet/navigation/navigation_style.cljs
+++ b/app/frontend/src/cljs/teet/navigation/navigation_style.cljs
@@ -61,15 +61,17 @@
   (with-meta
     {:display :flex
      :flex-direction :column
-      :top 0
-      :bottom :auto
-      :background-color theme-colors/white
-      :color theme-colors/gray-dark
-      :height theme-spacing/appbar-height
-      :box-shadow "0px 2px 4px rgba(0, 0, 0, 0.36)"
-      :transition "all 0.2s ease-in-out"}
-    (responsivity-styles/mobile-only-meta
-      {:height theme-spacing/appbar-height-mobile})))
+     :top 0
+     :bottom :auto
+     :background-color theme-colors/white
+     :border-bottom "1px solid #D2D3D8"
+     :color theme-colors/gray-dark
+     :height theme-spacing/appbar-height
+     :transition "all 0.2s ease-in-out"}
+    (merge (responsivity-styles/mobile-only-meta
+             {:height theme-spacing/appbar-height-mobile})
+           {:pseudo {:last-of-type {:border-bottom "none"
+                                    :box-shadow "0px 2px 4px rgba(0, 0, 0, 0.36)"}}})))
 
 (defn appbar-position [drawer-open?]
   (with-meta

--- a/app/frontend/src/cljs/teet/navigation/navigation_style.cljs
+++ b/app/frontend/src/cljs/teet/navigation/navigation_style.cljs
@@ -73,13 +73,16 @@
 
 (defn appbar-position [drawer-open?]
   (with-meta
-    {:z-index 10
-     :height theme-spacing/appbar-height-mobile}
-    (responsivity-styles/desktop-only-meta
-      (let [dw (drawer-width drawer-open?)]
-        {:width (str "calc(100% - " dw "px)")
-         :height theme-spacing/appbar-height
-         :margin-left (str dw "px")}))))
+    {:height theme-spacing/appbar-height-mobile}
+    (merge
+      (responsivity-styles/desktop-only-meta
+        (let [dw (drawer-width drawer-open?)]
+          {:width (str "calc(100% - " dw "px)")
+           :height theme-spacing/appbar-height
+           :margin-left (str dw "px")}))
+      ;; Add z-index only to first appbar, so that second appbar will not be on top of quick search
+      ;; or other extra-panels
+      {:pseudo {:first-of-type {:z-index 10}}})))
 
 (defn main-container [drawer-open?]
   (with-meta

--- a/app/frontend/src/cljs/teet/ui/buttons.cljs
+++ b/app/frontend/src/cljs/teet/ui/buttons.cljs
@@ -131,15 +131,17 @@
                              :type      :button}))
 
 (defn stand-alone-icon-button
-  [{:keys [id on-click icon class href ref]}]
-  [IconButton {:size :small
-               :class (collection/combine-and-flatten
-                        class
-                        (<class common-styles/stand-alone-icon-button-style))
-               :on-click on-click
-               :href href
-               :ref ref
-               :id id}
+  [{:keys [id on-click icon class href ref data-cy]}]
+  [IconButton (merge {:size :small
+                      :class (collection/combine-and-flatten
+                               class
+                               (<class common-styles/stand-alone-icon-button-style))
+                      :on-click on-click
+                      :href href
+                      :ref ref
+                      :id id}
+                     (when data-cy
+                       {:data-cy data-cy}))
    icon])
 
 (defn link-button-with-icon


### PR DESCRIPTION
- Add z-index only to first appbar, so that second appbar will not be on top of quick search or other extra-panels
- Add box-shadow for last appbar, and border-bottom for others, so that UI looks more like Figma design